### PR TITLE
Plugin Injection

### DIFF
--- a/packages/api/src/Api.ts
+++ b/packages/api/src/Api.ts
@@ -33,18 +33,43 @@ const Types = require('@cennznet/types');
 
 export class Api extends ApiPromise {
     static async create(options: ApiOptions | ProviderInterface = {}): Promise<Api> {
-        return new Api(options).isReady;
+        return new Api(options).isReady as Promise<Api>;
     }
 
     // TODO: add other crml namespaces
+    
+    private _genericAsset?: GenericAsset;
+    private _cennzxSpot?: CennzxSpot;
+
     /**
      * Generic Asset CRML extention
      */
-    genericAsset?: GenericAsset;
+    get genericAsset(): GenericAsset {
+        if (!this._genericAsset) {
+            throw new Error('Generic Asset plugin has not been injected.');
+        }
+
+        return this._genericAsset;
+    }
+
+    set genericAsset(value: GenericAsset) {
+        this._genericAsset = value;
+    }
+
     /**
      * Cennzx Spot CRML extention
      */
-    cennzxSpot?: CennzxSpot;
+    get cennzxSpot(): CennzxSpot {
+        if (!this._cennzxSpot) {
+            throw new Error('Cennzx Spot plugin has not been injected.');
+        }
+
+        return this._cennzxSpot;
+    }
+
+    set cennzxSpot(value: CennzxSpot) {
+        this._cennzxSpot = value;
+    }
 
     constructor(provider: ApiOptions | ProviderInterface = {}) {
         const options =

--- a/packages/api/src/Api.ts
+++ b/packages/api/src/Api.ts
@@ -37,38 +37,21 @@ export class Api extends ApiPromise {
     }
 
     // TODO: add other crml namespaces
-    
-    private _genericAsset?: GenericAsset;
-    private _cennzxSpot?: CennzxSpot;
 
     /**
      * Generic Asset CRML extention
      */
     get genericAsset(): GenericAsset {
-        if (!this._genericAsset) {
-            throw new Error('Generic Asset plugin has not been injected.');
-        }
-
-        return this._genericAsset;
-    }
-
-    set genericAsset(value: GenericAsset) {
-        this._genericAsset = value;
+        // `injectPlugins` will override this getter.
+        throw new Error('Generic Asset plugin has not been injected.');
     }
 
     /**
      * Cennzx Spot CRML extention
      */
     get cennzxSpot(): CennzxSpot {
-        if (!this._cennzxSpot) {
-            throw new Error('Cennzx Spot plugin has not been injected.');
-        }
-
-        return this._cennzxSpot;
-    }
-
-    set cennzxSpot(value: CennzxSpot) {
-        this._cennzxSpot = value;
+        // `injectPlugins` will override this getter.
+        throw new Error('Cennzx Spot plugin has not been injected.');
     }
 
     constructor(provider: ApiOptions | ProviderInterface = {}) {

--- a/packages/api/src/ApiRx.ts
+++ b/packages/api/src/ApiRx.ts
@@ -33,18 +33,43 @@ const Types = require('@cennznet/types');
 
 export class ApiRx extends ApiRxBase {
     static create(options: ApiOptions | ProviderInterface = {}): Observable<ApiRx> {
-        return new ApiRx(options).isReady;
+        return new ApiRx(options).isReady as Observable<ApiRx>;
     }
 
     // TODO: add other crml namespaces
+    
+    private _genericAsset?: GenericAssetRx;
+    private _cennzxSpot?: CennzxSpotRx;
+
     /**
      * Generic Asset CRML extention
      */
-    genericAsset?: GenericAssetRx;
+    get genericAsset(): GenericAssetRx {
+        if (!this._genericAsset) {
+            throw new Error('Generic Asset plugin has not been injected.');
+        }
+
+        return this._genericAsset;
+    }
+
+    set genericAsset(value: GenericAssetRx) {
+        this._genericAsset = value;
+    }
+
     /**
      * Cennzx Spot CRML extention
      */
-    cennzxSpot?: CennzxSpotRx;
+    get cennzxSpot(): CennzxSpotRx {
+        if (!this._cennzxSpot) {
+            throw new Error('Cennzx Spot plugin has not been injected.');
+        }
+
+        return this._cennzxSpot;
+    }
+
+    set cennzxSpot(value: CennzxSpotRx) {
+        this._cennzxSpot = value;
+    }
 
     constructor(provider: ApiOptions | ProviderInterface = {}) {
         const options =

--- a/packages/api/src/ApiRx.ts
+++ b/packages/api/src/ApiRx.ts
@@ -37,38 +37,21 @@ export class ApiRx extends ApiRxBase {
     }
 
     // TODO: add other crml namespaces
-    
-    private _genericAsset?: GenericAssetRx;
-    private _cennzxSpot?: CennzxSpotRx;
 
     /**
      * Generic Asset CRML extention
      */
     get genericAsset(): GenericAssetRx {
-        if (!this._genericAsset) {
-            throw new Error('Generic Asset plugin has not been injected.');
-        }
-
-        return this._genericAsset;
-    }
-
-    set genericAsset(value: GenericAssetRx) {
-        this._genericAsset = value;
+        // `injectPlugins` will override this getter.
+        throw new Error('Generic Asset plugin has not been injected.');
     }
 
     /**
      * Cennzx Spot CRML extention
      */
     get cennzxSpot(): CennzxSpotRx {
-        if (!this._cennzxSpot) {
-            throw new Error('Cennzx Spot plugin has not been injected.');
-        }
-
-        return this._cennzxSpot;
-    }
-
-    set cennzxSpot(value: CennzxSpotRx) {
-        this._cennzxSpot = value;
+        // `injectPlugins` will override this getter.
+        throw new Error('Cennzx Spot plugin has not been injected.');
     }
 
     constructor(provider: ApiOptions | ProviderInterface = {}) {


### PR DESCRIPTION
This PR ensures that:

* `genericAsset` is typed as `GenericAsset`, as opposed to `GenericAsset | undefined`.
* `cennzxSpot` is typed as `CennzxSpot`, as opposed to `CennzxSpot | undefined`.
* Consumers of this API, using TypeScript, do not need to add unnecessary guards if they have instantiated an instance of `Api` by `await`'ing a call to `Api.create()`.