### PR TITLE
`getProvider()` Unit Tests

### DIFF
--- a/packages/api/src/util/getProvider.spec.ts
+++ b/packages/api/src/util/getProvider.spec.ts
@@ -14,7 +14,9 @@
 
 import {HttpProvider, WsProvider} from '@plugnet/rpc-provider';
 
-import {getProvider} from './util/getProvider';
+import {getProvider} from './getProvider';
+
+jest.mock('@plugnet/rpc-provider');
 
 describe('getProvider()', () => {
     it('will create a ws provider if the string is a valid url and start with ws or wss', () => {


### PR DESCRIPTION
This PR ensures that:

* Unit tests do not instantiate real `HttpProvider`'s or `WsProvider`'s.
* Unit tests live closer to the SUT.