### PR TITLE
Refactor extrinsic + doughnut to use v0 binary codec 🍩

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -41,6 +41,7 @@
         "ts-mockito": "^2.3.1",
         "typedoc": "^0.13.0",
         "typedoc-plugin-markdown": "^1.1.19",
-        "typescript": "^3.4.5"
+        "typescript": "^3.4.5",
+        "cennznut.js": "github:cennznet/cennznut.js#v1.0.0"
     }
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DoughnutValue, FeeExchangeValue} from '@cennznet/types/extrinsic/Extrinsic';
+import {Doughnut} from '@cennznet/types/extrinsic/Doughnut';
+import {FeeExchangeValue} from '@cennznet/types/extrinsic/Extrinsic';
 import {DeriveCustom} from '@plugnet/api-derive';
 import {SubmittableExtrinsic} from '@plugnet/api/SubmittableExtrinsic';
 import {ApiOptions as ApiOptionsBase} from '@plugnet/api/types';
@@ -36,7 +37,7 @@ export type AnyAddress = BN | Address | AccountId | Array<number> | Uint8Array |
 
 export interface ICennznetExtrinsic<CodecResult, SubscriptionResult>
     extends SubmittableExtrinsic<CodecResult, SubscriptionResult> {
-    addDoughnut(doughnut: DoughnutValue): this;
+    addDoughnut(doughnut: Doughnut): this;
     addFeeExchangeOpt(feeExchangeOpt: FeeExchangeValue): this;
 }
 

--- a/packages/api/test/e2e/doughnut.e2e.ts
+++ b/packages/api/test/e2e/doughnut.e2e.ts
@@ -1,0 +1,109 @@
+// Copyright 2019 Centrality Investments Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import testingPairs from '@plugnet/keyring/testingPairs';
+import {waitReady} from '@polkadot/wasm-crypto';
+import {Api} from '../../src/Api';
+import {Doughnut} from '@cennznet/types/extrinsic/Doughnut';
+import {KeyringPair} from '@cennznet/util/types';
+import {Keypair} from '@plugnet/util-crypto/types';
+import {hexToU8a} from '@plugnet/util'
+
+const doughnut_maker = require('doughnut-maker');
+const cennznut = require('cennznut.js');
+
+/**
+ * Create a new unsigned Doughnut
+ */
+function makeDoughnut(holder: KeyringPair, issuer: Keypair): Doughnut {
+
+  // Create a valid CENNZnet domain permissions
+  const cennznetDomain = {
+    modules: {
+      'generic-asset': {
+        methods: {
+          'transfer': {
+            blockCooldown: 100
+          }
+        }
+      }
+    }
+  };
+
+  // Hack together an encoded domain for now
+  const encodedDomainPayload = cennznut.versions['0'].encode(cennznetDomain);
+  const encodedDomain = new Uint8Array(encodedDomainPayload.length + 2);
+  encodedDomain.set(encodedDomainPayload, 2);
+
+  const expiry = Math.ceil(Date.now() / 1000) + 60;
+
+  return new Doughnut(doughnut_maker.generate(0, 0, {
+    "issuer": issuer.publicKey,
+    "holder": holder.publicKey(),
+    "expiry": expiry,
+    "permissions": {
+      "cennznet": encodedDomain,
+    }
+  }, issuer));
+}
+
+describe('Doughnut for CennznetExtrinsic', () => {
+  let api: Api;
+  let keyring;
+
+  beforeAll(async () => {
+    await waitReady();
+  })
+
+  beforeEach(async () => {
+    if (!api) {
+      // TODO: Change to Rimu when doughnut goes live...
+      // api = await Api.create({provider: 'wss://rimu.unfrastructure.io/public/ws'});
+      api = await Api.create({ provider: 'ws://localhost:9944' });
+      keyring = testingPairs({ type: 'sr25519' });
+    }
+  });
+
+  afterEach(() => {
+    jest.setTimeout(5000);
+  });
+
+  it('It issues a doughnut with GA transfer for CENNZnet domain', async done => {
+    const tradeAssetId = 16001;
+    const receiver = keyring.bob;
+    const holder = keyring.dave;
+    const issuer = {
+      "secretKey": hexToU8a('0xa8f2d83016052e5d6d77b2f6fd5d59418922a09024cda701b3c34369ec43a7668faf12ff39cd4e5d92bb773972f41a7a5279ebc2ed92264bed8f47d344f8f18c'),
+      "publicKey": hexToU8a('0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22')
+    };
+
+    const tx = api.tx.genericAsset.transfer(tradeAssetId, receiver.address(), 10000);
+    let doughnut = makeDoughnut(holder, issuer);
+    tx.addDoughnut(doughnut);
+
+    return tx.signAndSend(holder, ({ events, status }) => {
+      console.log('Transaction status:', status.type);
+      if (status.isFinalized) {
+        console.log('Completed at block hash', status.value.toHex());
+        console.log('Events:');
+
+        events.forEach(({ phase, event: { data, method, section } }) => {
+          console.log('\t', phase.toString(), `: ${section}.${method}`, data.toString());
+        });
+
+        done();
+      }
+    });
+  });
+});

--- a/packages/types/src/extrinsic/Doughnut.ts
+++ b/packages/types/src/extrinsic/Doughnut.ts
@@ -12,32 +12,73 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AccountId, Signature, Struct, Text, Tuple, U32, U64, Vector} from '@plugnet/types';
+import {u8aToHex} from '@plugnet/util';
 
-export class Certificate extends Struct {
-    constructor(value?: any) {
-        super(
-            {
-                expires: U64,
-                version: U32,
-                holder: AccountId,
-                notBefore: U64,
-                permissions: Vector.with(Tuple.with([Text, Text])),
-                issuer: AccountId,
-            },
-            value
-        );
+/**
+ * An encoded, signed v0 Doughnut certificate
+ *
+ * Doughnut has its own binary codec. We hide this behind the parity codec interface
+ * to support integration as an extrinsic data/field.
+ *
+ **/
+export class Doughnut extends Uint8Array {
+    /**
+     * @description The length of the value when encoded as a Uint8Array
+     */
+    get isEmpty(): boolean {
+        return this.encodedLength == 0;
     }
-}
 
-export class Doughnut extends Struct {
-    constructor(value?: any) {
-        super(
-            {
-                certificate: Certificate,
-                signature: Signature,
-            },
-            value
-        );
+    /**
+     * @description Decode a Doughnut from a Uint8Array
+     * @param encoded A doughnut in v0 binary format, fails otherwise
+     */
+    decode(encoded: Uint8Array): Doughnut | undefined {
+        return encoded as Doughnut;
+    }
+
+    /**
+     * @description The length of the value when encoded as a Uint8Array
+     */
+    get encodedLength(): number {
+        return this.length;
+    }
+
+    /**
+     * @description Returns a hex string representation of the value
+     */
+    toHex(): string {
+        return u8aToHex(this);
+    }
+
+    /**
+     * @description Encodes the value as a Uint8Array as per the parity-codec specifications
+     * @param isBare true when the value has none of the type-specific prefixes (internal)
+     */
+    toU8a(isBare?: boolean): Uint8Array {
+        return this as Uint8Array;
+    }
+
+    /**
+     * @description Converts the Object to JSON, typically used for RPC transfers
+     */
+    toJSON(): any {
+        return this.values();
+    }
+
+    /**
+     * @description Returns the string representation of the value
+     */
+    toString(): string {
+        return this.toHex();
+    }
+
+    /**
+     * @description Compares the value of the input to see if there is a match
+     */
+    eq(other?: any): boolean {
+        // TODO: This is just to satisfy the interface.
+        // Expecting feedback on correct implementation in PR review
+        return Object.is(this, other);
     }
 }

--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -15,11 +15,11 @@
 
 import {assert, blake2AsU8a} from '@cennznet/util';
 import {KeyringPair} from '@plugnet/keyring/types';
-import {Address, Compact, Hash, Method, Signature, Struct} from '@plugnet/types';
+import {Address, Compact, Hash, Method, Struct} from '@plugnet/types';
 import {FunctionMetadata} from '@plugnet/types/Metadata/v0/Modules';
 import {AnyNumber, AnyU8a, ArgsDef, Codec, IExtrinsic, SignatureOptions} from '@plugnet/types/types';
 import {isHex, isU8a, u8aToHex, u8aToU8a} from '@plugnet/util';
-import {Certificate, Doughnut} from './Doughnut';
+import {Doughnut} from './Doughnut';
 import ExtrinsicSignature, {checkDoughnut, checkFeeExchange} from './ExtrinsicSignature';
 import FeeExchange from './FeeExchange';
 
@@ -33,11 +33,6 @@ type ExtrinsicValue = {
 export type FeeExchangeValue = {
     assetId: AnyNumber;
     maxPayment: AnyNumber;
-};
-
-export type DoughnutValue = {
-    certificate: Certificate;
-    signature: Signature;
 };
 
 // tslint:disable member-ordering no-magic-numbers
@@ -218,11 +213,12 @@ export default class Extrinsic extends Struct implements IExtrinsic {
     }
 
     /**
-     * @description append doughnut to Extrinsic
+     * @description Sign and attach a doughnut to the Extrinsic
+     * @param doughnut An unsigned Doughnut
      */
-    addDoughnut(doughnut: DoughnutValue): Extrinsic {
+    addDoughnut(doughnut: Doughnut): Extrinsic {
         assert(doughnut, 'doughnut is empty');
-        this.set('doughnut', new Doughnut(doughnut));
+        this.set('doughnut', doughnut);
         this.signature.withDoughnut();
         return this;
     }

--- a/packages/types/src/extrinsic/index.ts
+++ b/packages/types/src/extrinsic/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {Doughnut, Certificate} from './Doughnut';
+export {Doughnut} from './Doughnut';
 export {default as Extrinsic} from './Extrinsic';
 export {default as ExtrinsicSignature} from './ExtrinsicSignature';
 export {default as FeeExchange} from './FeeExchange';


### PR DESCRIPTION
Refactor the Extrinsic doughnut type as a `Uint8Array`

This allows a doughnut _holder_ to attach an issued doughnut for use.
The `Uint8Array` is a signed, binary encoded doughnut.

NB: _Issuers_ signing doughnuts may be supported by our wallet as a separate feature.
The doughnut codec is generic and in its own package: `doughnut-maker`
