### PR TITLE
fix: change peerDependencies to dependencies in crml-attestation/package.json

### DIFF
--- a/packages/crml-attestation/package.json
+++ b/packages/crml-attestation/package.json
@@ -12,10 +12,10 @@
         "url": "git+ssh://git@github.com/cennznet/api.js.git"
     },
     "scripts": {},
-    "peerDependencies": {
-        "@cennznet/api": "^0.20.3",
-        "@cennznet/types": "^0.20.3",
-        "@cennznet/util": "^0.20.3"
+    "dependencies": {
+        "@cennznet/api": "^0.20.7",
+        "@cennznet/types": "^0.20.7",
+        "@cennznet/util": "^0.20.7"
     },
     "devDependencies": {
         "@cennznet/wallet": "^0.20.7",


### PR DESCRIPTION
A missing piece should be done when I put crml-attestation into this repo.