### PR TITLE
Fix cennznet docker image version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   testnet_node_alice:
     container_name: testnet_node_alice
-    image: cennznet/cennznet:latest
+    image: cennznet/cennznet@sha256:c8f5f7dd93b044db3c5ffff71344c292669cd788bc7ab4bdfa1d1c48090f312b
     command:
       - --chain=dev
       - --base-path=/mnt/node


### PR DESCRIPTION
Its better to ensure api.js work with a specific tag/version of cennznet node whenever we release, as we are not able to ensure api always work with the latest cennznet.