### PR TITLE
Add missing types for Sylo

### DIFF
--- a/packages/types/src/runtime/sylo/index.ts
+++ b/packages/types/src/runtime/sylo/index.ts
@@ -127,3 +127,7 @@ export class Response extends Enum.with({DeviceIdResponse, PreKeyBundlesResponse
 export class VaultKey extends ClassOf(registry, 'Bytes') {}
 
 export class VaultValue extends ClassOf(registry, 'Bytes') {}
+
+export class MessageId extends ClassOf(registry, 'u32') {}
+
+export class Message extends ClassOf(registry, 'Bytes') {}


### PR DESCRIPTION
As part of Sylo module audit, we introduced Message and MessageId types (https://github.com/cennznet/cennznet/pull/180)