### PR TITLE
Chore/generate slim data

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:e2e": "TEST_TYPE=e2e jest -c ./jest/integration.config.js --bail  --forceExit --detectOpenHandles",
     "make-docs": "rm -rf api_docs && typedoc --plugin typedoc-plugin-markdown --options typedoc.config.js .",
     "metadata-docs": "node ./scripts/MetadataMdWrapper.js",
+    "generate-slim-metadata": "node ./scripts/generateSlimMetadataWrapper.js",
     "lint": "npx tslint -c tslint.json --project . && npx prettier --list-different './packages/**/src/*.ts'"
   },
   "devDependencies": {

--- a/scripts/generateSlimMetadata.ts
+++ b/scripts/generateSlimMetadata.ts
@@ -1,0 +1,86 @@
+// Running this file with ~ node scripts/updateStaticMetadata.js will create a staticMetadata.ts on root directory which can used/copied
+import {Api} from '../packages/api/src/Api';
+import MetadataVersioned from '@polkadot/metadata/Metadata/MetadataVersioned';
+import {toCallsOnly} from '@polkadot/metadata/Metadata/util';
+
+import {createType} from '@cennznet/types';
+
+async function generateSlimMeta() {
+    // const provider = 'wss://cennznet.unfrastructure.io/public/ws'; // Use Azalea
+    const provider = 'ws://127.0.0.1:9944';
+    const api = await Api.create({provider});
+    const metadata = api.runtimeMetadata.toJSON();
+    const keep = [
+        "System",
+        "Timestamp",
+        "TransactionPayment",
+        "GenericAsset",
+        "SyloGroups",
+        "SyloE2EE",
+        "SyloDevice",
+        "SyloInbox",
+        "SyloResponse",
+        "SyloVault",
+        "CennzxSpot",
+    ];
+    // metadata.asV11.modules
+    console.log('Orignal Meta: ',JSON.stringify(metadata));
+    let magicNumber = metadata.magicNumber;
+  //  let modules = metadata.metadata['V11'].modules;
+    let modules = api.runtimeMetadata.asV11.modules;
+    console.log('Modules::', JSON.stringify(modules));
+    let newModules = [];
+    for (const m of modules) {
+        if (keep.indexOf(m.name.toJSON()) >= 0) {
+            console.log("keeping", m.name.toJSON());
+            newModules.push(m);
+        } else {
+            // Push an empty module
+            console.log("slimming", m.name.toJSON());
+            newModules.push({"name": m.name, "calls": m.calls, "events": m.events});
+        }
+    }
+    console.log('New modules::', JSON.stringify(newModules));
+    let extrinsic = metadata.metadata['V11'].extrinsic;
+    let filteredModule = createType(api.registry, 'Vec<ModuleMetadataV11>', newModules);
+    let filteredMetaLatest = createType(api.registry, 'MetadataLatest', {modules: filteredModule, extrinsic});
+    const filteredMetadata = createType(api.registry,'MetadataAll', toCallsOnly(api.registry, filteredMetaLatest), 11);
+    // removeKeys(filteredMetadata, "documentation");
+    const mVersionedNew = new MetadataVersioned(api.registry, {
+        magicNumber: magicNumber,
+        metadata: filteredMetadata
+    });
+    console.log('metadata hex:', mVersionedNew.toHex());
+    console.log('Meta data:', JSON.stringify(mVersionedNew.asV11));
+
+    process.exit();
+}
+
+function removeKeys(obj, keys){
+    var index;
+    for (var prop in obj) {
+        // important check that this is objects own property
+        // not from prototype prop inherited
+        if(obj.hasOwnProperty(prop)){
+            switch(typeof(obj[prop])){
+                case 'string':
+                    index = keys.indexOf(prop);
+                    if(index > -1){
+                        delete obj[prop];
+                    }
+                    break;
+                case 'object':
+                    index = keys.indexOf(prop);
+                    if(index > -1){
+                        delete obj[prop];
+                    }else{
+                        removeKeys(obj[prop], keys);
+                    }
+                    break;
+            }
+        }
+    }
+}
+
+
+generateSlimMeta();

--- a/scripts/generateSlimMetadata.ts
+++ b/scripts/generateSlimMetadata.ts
@@ -1,7 +1,6 @@
-// Running this file with ~ node scripts/updateStaticMetadata.js will create a staticMetadata.ts on root directory which can used/copied
+// Running this file with ~ yarn generate-slim-metadata will create slim metadata
 import {Api} from '../packages/api/src/Api';
 import MetadataVersioned from '@polkadot/metadata/Metadata/MetadataVersioned';
-import {toCallsOnly} from '@polkadot/metadata/Metadata/util';
 
 import {createType} from '@cennznet/types';
 

--- a/scripts/generateSlimMetadata.ts
+++ b/scripts/generateSlimMetadata.ts
@@ -1,15 +1,23 @@
-// Running this file with ~ yarn generate-slim-metadata will create slim metadata
+// Running this file with ~ yarn generate-slim-metadata 'wss://cennznet.unfrastructure.io/public/ws' will create slim metadata
 import {Api} from '../packages/api/src/Api';
 import MetadataVersioned from '@polkadot/metadata/Metadata/MetadataVersioned';
 
 import {createType} from '@cennznet/types';
 
+// Metadata is slimmed as follows:
+// This function will remove all the documentation for each module in the chain.
+// Moreover it will only keep the complete information (structure) of most essential modules/sections required to meet the
+// basic functionality like connect to the chain, use generic asset features, CENNZX features and all SYLO module's functionality
+// MOST ESSENTIAL Modules can be seen in the KEEP list below.
+// For everything else it will trim down the module structure to just use name, calls and events.
+// While generating metadata we should try to connect to an endpoint which is running the desired version of CENNZnet.
+// END POINT can be passed as command line argument - yarn generate-slim-metadata 'ws://localhost:9944', by default Azalea would be used
+
 async function generateSlimMeta() {
-    // const provider = 'wss://cennznet.unfrastructure.io/public/ws'; // Use Azalea
-    const provider = 'ws://127.0.0.1:9944';
+    const provider: any = process.argv[2] ? process.argv[2]: 'wss://cennznet.unfrastructure.io/public/ws';
     const api = await Api.create({provider});
     const metadata = api.runtimeMetadata.toJSON();
-    const keep = [
+    const KEEP = [
         "System",
         "Timestamp",
         "TransactionPayment",
@@ -26,7 +34,7 @@ async function generateSlimMeta() {
     let modules = api.runtimeMetadata.asV11.modules;
     let newModules = [];
     for (const m of modules) {
-        if (keep.indexOf(m.name.toJSON()) >= 0) {
+        if (KEEP.indexOf(m.name.toJSON()) >= 0) {
             const module = m.toJSON();
             removeKeys(module, "documentation");
             // Creating ModuleMetadataV11

--- a/scripts/generateSlimMetadata.ts
+++ b/scripts/generateSlimMetadata.ts
@@ -23,35 +23,30 @@ async function generateSlimMeta() {
         "SyloVault",
         "CennzxSpot",
     ];
-    // metadata.asV11.modules
-    console.log('Orignal Meta: ',JSON.stringify(metadata));
     let magicNumber = metadata.magicNumber;
-  //  let modules = metadata.metadata['V11'].modules;
     let modules = api.runtimeMetadata.asV11.modules;
-    console.log('Modules::', JSON.stringify(modules));
     let newModules = [];
     for (const m of modules) {
         if (keep.indexOf(m.name.toJSON()) >= 0) {
-            console.log("keeping", m.name.toJSON());
-            newModules.push(m);
+            const module = m.toJSON();
+            removeKeys(module, "documentation");
+            // Creating ModuleMetadataV11
+            let modifiedModule = createType(api.registry, 'ModuleMetadataV11', module);
+            newModules.push(modifiedModule);
         } else {
             // Push an empty module
-            console.log("slimming", m.name.toJSON());
             newModules.push({"name": m.name, "calls": m.calls, "events": m.events});
         }
     }
-    console.log('New modules::', JSON.stringify(newModules));
     let extrinsic = metadata.metadata['V11'].extrinsic;
     let filteredModule = createType(api.registry, 'Vec<ModuleMetadataV11>', newModules);
     let filteredMetaLatest = createType(api.registry, 'MetadataLatest', {modules: filteredModule, extrinsic});
-    const filteredMetadata = createType(api.registry,'MetadataAll', toCallsOnly(api.registry, filteredMetaLatest), 11);
-    // removeKeys(filteredMetadata, "documentation");
+    const filteredMetadataAll = createType(api.registry,'MetadataAll', filteredMetaLatest, 11);
     const mVersionedNew = new MetadataVersioned(api.registry, {
         magicNumber: magicNumber,
-        metadata: filteredMetadata
+        metadata: filteredMetadataAll
     });
     console.log('metadata hex:', mVersionedNew.toHex());
-    console.log('Meta data:', JSON.stringify(mVersionedNew.asV11));
 
     process.exit();
 }

--- a/scripts/generateSlimMetadataWrapper.js
+++ b/scripts/generateSlimMetadataWrapper.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Copyright 2017-2019 @polkadot/types authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+require('@babel/register')({
+    extensions: ['.js', '.ts'],
+    plugins: [
+        ['module-resolver', {
+            alias: {
+                '^@cennznet/api(.*)': './packages/api/src\\1',
+                '^@cennznet/types(.*)': './packages/types/src\\1',
+                '^@cennznet/crml-attestation(.*)': './packages/crml-attestation/src\\1',
+                '^@cennznet/crml-cennzx-spot(.*)': './packages/crml-cennzx-spot/src\\1',
+                '^@cennznet/crml-generic-asset(.*)': './packages/crml-generic-asset/src\\1',
+                '^@cennznet/util(.*)': './packages/util/src\\1',
+            }
+        }]
+    ]
+});
+
+require('./generateSlimMetadata.ts');


### PR DESCRIPTION
Added script to generate slim meta data for Sylo.. 
Meta data generated has been tested against connection and GA transfer.
The size of meta data has further reduced to 83,652.
Have tested it against local host, but can be modified once Azalea is upgraded?
`yarn generate-slim-metadata 'end-point'` will generate the new slim metadata