### PR TITLE
Support underscore in number with babel plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
       #     name: Run lint
       #     command: yarn lint
       - run:
+           name: Build
+           command: yarn build
+      - run:
           name: Run unit tests
           command: yarn test --coverage
       - store_test_results:

--- a/babel.config.js
+++ b/babel.config.js
@@ -6,6 +6,7 @@ module.exports = {
       "define": {
         "DOUGHNUT_SUPPORT": false
       }
-    }]
+    }],
+    "@babel/plugin-proposal-numeric-separator"
   ]
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
+    "@babel/plugin-proposal-numeric-separator": "^7.10.4",
     "babel-plugin-conditional-compile": "^0.0.5",
     "@babel/core": "^7.7.4",
     "@babel/preset-env": "^7.7.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,6 +214,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
   integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
 
+"@babel/helper-plugin-utils@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
+  integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
+
 "@babel/helper-regex@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.8.3.tgz#139772607d51b93f23effe72105b319d2a4c6965"
@@ -340,6 +345,14 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
+"@babel/plugin-proposal-numeric-separator@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz#ce1590ff0a65ad12970a609d78855e9a4c1aef06"
+  integrity sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+
 "@babel/plugin-proposal-object-rest-spread@^7.3.4", "@babel/plugin-proposal-object-rest-spread@^7.6.2", "@babel/plugin-proposal-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz#eb5ae366118ddca67bed583b53d7554cad9951bb"
@@ -421,6 +434,13 @@
   integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-numeric-separator@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz#b9b070b3e33570cd9fd07ba7fa91c0dd37b9af97"
+  integrity sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.2.0", "@babel/plugin-syntax-object-rest-spread@^7.8.0":
   version "7.8.3"


### PR DESCRIPTION
While making a release with recent changes had this issue on Jenkins pipeline and build failed

Browserslist: caniuse-lite is outdated. Please run the following command: `yarn upgrade`
{ SyntaxError: /workdir/packages/types/src/runtime/ga/WithdrawReasons.ts: Identifier directly after number (20:29)

  18 | const ReasonMask = {
  19 |   /// In order to pay for (system) transaction costs.
> 20 |   TRANSACTION_PAYMENT: 0b0000_0001,
     |                              ^
  21 |   /// In order to transfer ownership.
  22 |   TRANSFER: 0b0000_0010,
  23 |   /// In order to reserve some funds for a later return or repatriation.
    at Object.raise (/workdir/node_modules/@babel/parser/lib/index.js:7017:17)
    at Object.readRadixNumber (/workdir/node_modules/@babel/parser/lib/index.js:7876:18)
    at Object.getTokenFromCode (/workdir/node_modules/@babel/parser/lib/index.js:7645:18)
    at Object.getTokenFromCode (/workdir/node_modules/@babel/parser/lib/index.js:6394:20)
    at Object.nextToken (/workdir/node_modules/@babel/parser/lib/index.js:7241:12)
    at Object.next (/workdir/node_modules/@babel/parser/lib/index.js:7170:10)
    at Object.eat (/workdir/node_modules/@babel/parser/lib/index.js:7175:12)
    at Object.parseObjectProperty (/workdir/node_modules/@babel/parser/lib/index.js:10120:14)
    at Object.parseObjPropValue (/workdir/node_modules/@babel/parser/lib/index.js:10146:101)
    at Object.parseObjPropValue (/workdir/node_modules/@babel/parser/lib/index.js:6163:11)
  pos: 891,
  loc: Position { line: 20, column: 29 },
  code: 'BABEL_PARSE_ERROR' }
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
The command '/bin/sh -c yarn build' returned a non-zero code: 1

To address this, have added babel plugin https://babeljs.io/docs/en/babel-plugin-proposal-numeric-separator

I plan to rebase the release branch once I get this approved and merged.