### PR TITLE
Chore tslint/enable prefer const rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,7 +79,6 @@ module.exports = {
         // "no-magic-numbers": "error",
         "no-return-await": "error",
         "no-undef-init": "error",
-        "prefer-const": "off",
         "prefer-template": "error",
         "use-isnan": "error"
     }

--- a/packages/util/src/unit/parseUnits.ts
+++ b/packages/util/src/unit/parseUnits.ts
@@ -18,24 +18,23 @@ import {stripEndZero} from '../format/stripEndZero';
 import isSafeInteger from '../is/integer';
 import {toFixed} from '../number/toFixed';
 
-// tslint:disable prefer-const no-magic-numbers
 /**
  * format a amount from unit `un` to decimals passed in.
  * @param unValue
  * @param decimals
  */
 export default function parseUnits(value: string | number, decimals: number): BN {
-    const strValue = isNumber(value) ? toFixed(value) : value;
-    let [intPart, fractionPart] = strValue.split('.');
-    assert(isSafeInteger(intPart), 'intPart not a integer');
-    let retValue = new BN(intPart).mul(new BN(10).pow(new BN(decimals)));
-    fractionPart = stripEndZero(fractionPart || '');
-    if (fractionPart && fractionPart !== '') {
-        assert(isSafeInteger(fractionPart), 'fractionPart not a integer');
-        if (fractionPart.length > decimals) {
-            throw new Error('too much decimals');
-        }
-        retValue = retValue.add(new BN(fractionPart).mul(new BN(10).pow(new BN(decimals - fractionPart.length))));
+  const strValue = isNumber(value) ? toFixed(value) : value;
+  const [intPart, fractionalPart] = strValue.split('.');
+  assert(isSafeInteger(intPart), 'intPart not a integer');
+  let retValue = new BN(intPart).mul(new BN(10).pow(new BN(decimals)));
+  const fractionPart = stripEndZero(fractionalPart || '');
+  if (fractionPart && fractionPart !== '') {
+    assert(isSafeInteger(fractionPart), 'fractionPart not a integer');
+    if (fractionPart.length > decimals) {
+      throw new Error('too much decimals');
     }
-    return retValue;
+    retValue = retValue.add(new BN(fractionPart).mul(new BN(10).pow(new BN(decimals - fractionPart.length))));
+  }
+  return retValue;
 }


### PR DESCRIPTION
PR - To solve the rules either commented or set OFF.

This one is to enable the support for "prefer-const".
The file changed get auto-indentate..tried to update the formatting to what it was earlier but commit will auto format it with command - pretty-quick --staged --pattern 'packages/**/src/**/*'
  "husky": {
    "hooks": {
      "pre-commit": "pretty-quick --staged --pattern 'packages/**/src/**/*' && npx eslint . --ext .ts"
    }
  },
If required I can remove pretty-quick and push the changes again