### PR TITLE
Enable linting on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ jobs:
           paths:
             - ~/.tmp/yarn
           key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      # - run:
-      #     name: Run lint
-      #     command: yarn lint
+      - run:
+          name: Run lint
+          command: yarn lint
       - run:
            name: Build
            command: yarn build


### PR DESCRIPTION
Now that linting errors have been turned off in https://github.com/cennznet/api.js/pull/160/ , I suppose this easy fix could be merged with linting fix now.

https://app.circleci.com/pipelines/github/cennznet/api.js/491/workflows/4386c9e3-8f2c-4793-841f-17cf8f3ecce7/jobs/493

<img width="191" alt="Screen Shot 2020-08-25 at 3 17 03 PM" src="https://user-images.githubusercontent.com/1513326/91118904-1ce72b80-e6e6-11ea-8f57-463f385f5a90.png">
