### PR TITLE
 To format API with space after curly brace

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
   "trailingComma": "es5",
   "tabWidth": 2,
   "singleQuote": true,
-  "bracketSpacing": false
+  "bracketSpacing": true
 }

--- a/packages/api/src/Api.ts
+++ b/packages/api/src/Api.ts
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Attestation} from '@cennznet/crml-attestation';
-import {CennzxSpot} from '@cennznet/crml-cennzx-spot';
-import {GenericAsset} from '@cennznet/crml-generic-asset';
+import { Attestation } from '@cennznet/crml-attestation';
+import { CennzxSpot } from '@cennznet/crml-cennzx-spot';
+import { GenericAsset } from '@cennznet/crml-generic-asset';
 import Types from '@cennznet/types/injects';
-import {ApiPromise} from '@polkadot/api';
-import {ApiOptions as ApiOptionsBase} from '@polkadot/api/types';
+import { ApiPromise } from '@polkadot/api';
+import { ApiOptions as ApiOptionsBase } from '@polkadot/api/types';
 
 import derives from './derives';
 import rpc from './rpc';
 import staticMetadata from './staticMetadata';
-import {ApiOptions, Derives, SubmittableExtrinsics} from './types';
-import {mergeDeriveOptions} from './util/derives';
-import {getProvider} from './util/getProvider';
-import {getTimeout} from './util/getTimeout';
+import { ApiOptions, Derives, SubmittableExtrinsics } from './types';
+import { mergeDeriveOptions } from './util/derives';
+import { getProvider } from './util/getProvider';
+import { getTimeout } from './util/getTimeout';
 
 export const DEFAULT_TIMEOUT = 10000;
 
@@ -86,15 +86,15 @@ export class Api extends ApiPromise {
   }
 
   constructor(_options: ApiOptions = {}) {
-    const options = {..._options};
+    const options = { ..._options };
 
     if (typeof options.provider === 'string') {
       options.provider = getProvider(options.provider);
     }
     options.metadata = Object.assign(staticMetadata, options.metadata);
-    options.types = {...options.types, ...Types};
+    options.types = { ...options.types, ...Types };
     options.derives = mergeDeriveOptions(derives, options.derives);
-    options.rpc = {...(rpc as any), ...options.rpc};
+    options.rpc = { ...(rpc as any), ...options.rpc };
 
     super(options as ApiOptionsBase);
 

--- a/packages/api/src/ApiRx.ts
+++ b/packages/api/src/ApiRx.ts
@@ -12,24 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import getPlugins from '@cennznet/api/plugins';
-import {mergeDeriveOptions} from '@cennznet/api/util/derives';
-import {injectOption, injectPlugins, mergePlugins} from '@cennznet/api/util/injectPlugin';
-import {AttestationRx} from '@cennznet/crml-attestation';
-import {CennzxSpotRx} from '@cennznet/crml-cennzx-spot';
-import {GenericAssetRx} from '@cennznet/crml-generic-asset';
+import { mergeDeriveOptions } from '@cennznet/api/util/derives';
+import { injectOption, injectPlugins, mergePlugins } from '@cennznet/api/util/injectPlugin';
+import { AttestationRx } from '@cennznet/crml-attestation';
+import { CennzxSpotRx } from '@cennznet/crml-cennzx-spot';
+import { GenericAssetRx } from '@cennznet/crml-generic-asset';
 import Types from '@cennznet/types/injects';
-import {ApiRx as ApiRxBase} from '@polkadot/api';
-import {ApiOptions as ApiOptionsBase} from '@polkadot/api/types';
-import {fromEvent, Observable, race, throwError} from 'rxjs';
-import {switchMap, timeout} from 'rxjs/operators';
+import { ApiRx as ApiRxBase } from '@polkadot/api';
+import { ApiOptions as ApiOptionsBase } from '@polkadot/api/types';
+import { fromEvent, Observable, race, throwError } from 'rxjs';
+import { switchMap, timeout } from 'rxjs/operators';
 
 import rpc from '@cennznet/api/rpc';
-import {DEFAULT_TIMEOUT} from './Api';
+import { DEFAULT_TIMEOUT } from './Api';
 import derives from './derives';
 import staticMetadata from './staticMetadata';
-import {ApiOptions, Derives, IPlugin, SubmittableExtrinsics} from './types';
-import {getProvider} from './util/getProvider';
-import {getTimeout} from './util/getTimeout';
+import { ApiOptions, Derives, IPlugin, SubmittableExtrinsics } from './types';
+import { getProvider } from './util/getProvider';
+import { getTimeout } from './util/getTimeout';
 import logger from './util/logging';
 
 export class ApiRx extends ApiRxBase {
@@ -87,14 +87,14 @@ export class ApiRx extends ApiRxBase {
   }
 
   constructor(_options: ApiOptions = {}) {
-    const options = {..._options};
+    const options = { ..._options };
     if (typeof options.provider === 'string') {
       options.provider = getProvider(options.provider);
     }
     options.metadata = Object.assign(staticMetadata, options.metadata);
-    options.types = {...options.types, ...Types};
+    options.types = { ...options.types, ...Types };
     options.derives = mergeDeriveOptions(derives as any, options.derives);
-    options.rpc = {...(rpc as any), ...options.rpc};
+    options.rpc = { ...(rpc as any), ...options.rpc };
 
     super(options as ApiOptionsBase);
 

--- a/packages/api/src/derives/fees/estimateFee.ts
+++ b/packages/api/src/derives/fees/estimateFee.ts
@@ -1,14 +1,14 @@
-import {ApiInterfaceRx} from '@cennznet/api/types';
+import { ApiInterfaceRx } from '@cennznet/api/types';
 import Extrinsic from '@cennznet/types/extrinsic/Extrinsic';
-import {generateTransactionPayment} from '@cennznet/types/runtime/transaction-payment/TransactionPayment';
-import {AnyAssetId, IExtrinsic} from '@cennznet/types/types';
-import {drr} from '@polkadot/rpc-core/rxjs';
-import {TypeRegistry} from '@polkadot/types';
-import {RuntimeDispatchInfo} from '@polkadot/types/interfaces/rpc';
+import { generateTransactionPayment } from '@cennznet/types/runtime/transaction-payment/TransactionPayment';
+import { AnyAssetId, IExtrinsic } from '@cennznet/types/types';
+import { drr } from '@polkadot/rpc-core/rxjs';
+import { TypeRegistry } from '@polkadot/types';
+import { RuntimeDispatchInfo } from '@polkadot/types/interfaces/rpc';
 import ExtrinsicEra from '@polkadot/types/primitive/Extrinsic/ExtrinsicEra';
 import BN from 'bn.js';
-import {combineLatest, Observable, of} from 'rxjs';
-import {catchError, first, map, switchMap} from 'rxjs/operators';
+import { combineLatest, Observable, of } from 'rxjs';
+import { catchError, first, map, switchMap } from 'rxjs/operators';
 
 // This interface is to determine fee estimate for any transaction that is going to be executed..
 // The estimate can be in any currency(userFeeAssetId) provided there is enough liquidity in the exchange pool for that currency.
@@ -29,7 +29,7 @@ import {catchError, first, map, switchMap} from 'rxjs/operators';
 export function estimateFee(api: ApiInterfaceRx) {
   // We generate fake signature data here to ensure the estimated fee will correctly match the fee paid when the extrinsic is signed by a user.
   // This is because fees are currently based on the byte length of the extrinsic
-  return ({extrinsic, userFeeAssetId, maxPayment}): Observable<any> => {
+  return ({ extrinsic, userFeeAssetId, maxPayment }): Observable<any> => {
     return combineLatest([
       api.rpc.state.getRuntimeVersion(),
       api.rpc.chain.getBlockHash(),
@@ -49,8 +49,8 @@ export function estimateFee(api: ApiInterfaceRx) {
           const transactionPayment =
             userFeeAssetId.toString() === networkFeeAssetId.toString()
               ? null
-              : generateTransactionPayment({tip: 0, assetId: userFeeAssetId, maxPayment});
-          const payload = {runtimeVersion, era, blockHash, genesisHash, nonce, transactionPayment};
+              : generateTransactionPayment({ tip: 0, assetId: userFeeAssetId, maxPayment });
+          const payload = { runtimeVersion, era, blockHash, genesisHash, nonce, transactionPayment };
           (extrinsic as Extrinsic).signFake(fake_sender, payload as any);
           return combineLatest([api.rpc.payment.queryInfo(extrinsic.toHex()), of(networkFeeAssetId)]);
         }

--- a/packages/api/src/derives/fees/index.ts
+++ b/packages/api/src/derives/fees/index.ts
@@ -1,1 +1,1 @@
-export {estimateFee} from './estimateFee';
+export { estimateFee } from './estimateFee';

--- a/packages/api/src/derives/index.ts
+++ b/packages/api/src/derives/index.ts
@@ -12,24 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiTypes} from '@cennznet/api/types';
+import { ApiTypes } from '@cennznet/api/types';
 import * as attestation from '@cennznet/crml-attestation/derives';
 import * as cennzxSpot from '@cennznet/crml-cennzx-spot/derives';
 import * as genericAsset from '@cennznet/crml-generic-asset/derives';
-import {AnyFunction} from '@cennznet/types/types';
-import {ApiInterfaceRx, MethodResult} from '@polkadot/api/types';
-import {Observable} from 'rxjs';
+import { AnyFunction } from '@cennznet/types/types';
+import { ApiInterfaceRx, MethodResult } from '@polkadot/api/types';
+import { Observable } from 'rxjs';
 import * as fees from './fees';
 import * as session from './session';
 import * as staking from './staking';
 
 export type DeriveFunc = (api: ApiInterfaceRx) => (...args: any[]) => Observable<any>;
 
-export const derive = {attestation, cennzxSpot, fees, staking, session, genericAsset};
+export const derive = { attestation, cennzxSpot, fees, staking, session, genericAsset };
 
 export type DecoratedCennznetDerive<
   ApiType extends ApiTypes,
-  AllSections extends {[section: string]: {[method: string]: DeriveFunc}} = typeof derive
+  AllSections extends { [section: string]: { [method: string]: DeriveFunc } } = typeof derive
 > = {
   [SectionName in keyof AllSections]: {
     [MethodName in keyof AllSections[SectionName]]: ReturnType<AllSections[SectionName][MethodName]> extends AnyFunction

--- a/packages/api/src/derives/session/index.ts
+++ b/packages/api/src/derives/session/index.ts
@@ -1,2 +1,2 @@
-export {queryKeyInfo as keyInfo} from './keyInfo';
+export { queryKeyInfo as keyInfo } from './keyInfo';
 export * from '@polkadot/api-derive/session';

--- a/packages/api/src/derives/session/keyInfo.ts
+++ b/packages/api/src/derives/session/keyInfo.ts
@@ -1,17 +1,17 @@
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {memo} from '@polkadot/api-derive/util';
-import {createType, Option, Vec} from '@polkadot/types';
-import {AccountId, Keys} from '@polkadot/types/interfaces';
-import {ITuple} from '@polkadot/types/types';
-import {combineLatest, Observable, of} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
-import {DerivedSessionKeyInfo} from '../types';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { memo } from '@polkadot/api-derive/util';
+import { createType, Option, Vec } from '@polkadot/types';
+import { AccountId, Keys } from '@polkadot/types/interfaces';
+import { ITuple } from '@polkadot/types/types';
+import { combineLatest, Observable, of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { DerivedSessionKeyInfo } from '../types';
 
 function unwrapSessionIds(
   stashId: AccountId,
   queuedKeys: [AccountId, Keys][],
   nextKeys: Option<Keys>
-): {nextSessionKeys: AccountId[]; sessionKeys: AccountId[]} {
+): { nextSessionKeys: AccountId[]; sessionKeys: AccountId[] } {
   let sessionKeys: AccountId[] = [];
   const idKeys = queuedKeys.find(([currentId]): boolean => currentId.eq(stashId));
   if (idKeys) {

--- a/packages/api/src/derives/staking/index.ts
+++ b/packages/api/src/derives/staking/index.ts
@@ -1,4 +1,4 @@
-export {queryStakingAccountInfo as accountInfo} from './stakingAccount';
+export { queryStakingAccountInfo as accountInfo } from './stakingAccount';
 export * from '@polkadot/api-derive/staking/account';
 export * from '@polkadot/api-derive/staking/controllers';
 export * from '@polkadot/api-derive/staking/electedInfo';

--- a/packages/api/src/derives/staking/stakingAccount.ts
+++ b/packages/api/src/derives/staking/stakingAccount.ts
@@ -1,10 +1,10 @@
-import {Observable, of} from 'rxjs';
-import {map, switchMap} from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {RewardDestination} from '@cennznet/types';
-import {memo} from '@polkadot/api-derive/util';
-import {createType, Option} from '@polkadot/types';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { RewardDestination } from '@cennznet/types';
+import { memo } from '@polkadot/api-derive/util';
+import { createType, Option } from '@polkadot/types';
 import {
   AccountId,
   EraIndex,
@@ -14,7 +14,7 @@ import {
   StakingLedger,
   ValidatorPrefs,
 } from '@polkadot/types/interfaces';
-import {DerivedStakingInfo} from '../types';
+import { DerivedStakingInfo } from '../types';
 
 type MultiResultV2 = [
   Option<AccountId>,
@@ -59,7 +59,7 @@ export function queryStakingAccountInfo(
                     (stakingLedgerOpt): DerivedStakingInfo => ({
                       accountId: stashId,
                       controllerId,
-                      nominators: nominatorsOpt.unwrapOr({targets: []}).targets,
+                      nominators: nominatorsOpt.unwrapOr({ targets: [] }).targets,
                       rewardDestination,
                       stakers,
                       stakingLedger: stakingLedgerOpt.unwrapOr(undefined),
@@ -68,7 +68,7 @@ export function queryStakingAccountInfo(
                     })
                   )
                 )
-              : of({accountId: stashId});
+              : of({ accountId: stashId });
           }
         )
       );

--- a/packages/api/src/derives/types.ts
+++ b/packages/api/src/derives/types.ts
@@ -1,5 +1,5 @@
-import {RewardDestination} from '@cennznet/types';
-import {AccountId, EraIndex, Exposure, Keys, StakingLedger, ValidatorPrefs} from '@cennznet/types/interfaces';
+import { RewardDestination } from '@cennznet/types';
+import { AccountId, EraIndex, Exposure, Keys, StakingLedger, ValidatorPrefs } from '@cennznet/types/interfaces';
 
 export interface DerivedStakingInfo {
   accountId: AccountId;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {Api} from './Api';
-export {ApiRx} from './ApiRx';
+export { Api } from './Api';
+export { ApiRx } from './ApiRx';
 
-export {SubmittableResult} from '@polkadot/api';
-export {WsProvider, HttpProvider} from '@polkadot/rpc-provider';
+export { SubmittableResult } from '@polkadot/api';
+export { WsProvider, HttpProvider } from '@polkadot/rpc-provider';

--- a/packages/api/src/plugins.ts
+++ b/packages/api/src/plugins.ts
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {IPlugin} from '@cennznet/api/types';
-import {Plugin as CrmlAttestation} from '@cennznet/crml-attestation';
-import {Plugin as CrmlCennzx} from '@cennznet/crml-cennzx-spot';
-import {Plugin as CrmlGenericAsset} from '@cennznet/crml-generic-asset';
+import { IPlugin } from '@cennznet/api/types';
+import { Plugin as CrmlAttestation } from '@cennznet/crml-attestation';
+import { Plugin as CrmlCennzx } from '@cennznet/crml-cennzx-spot';
+import { Plugin as CrmlGenericAsset } from '@cennznet/crml-generic-asset';
 
 export default function getPlugins(): IPlugin[] {
   // @ts-ignore

--- a/packages/api/src/rpc/cennzx.ts
+++ b/packages/api/src/rpc/cennzx.ts
@@ -1,4 +1,4 @@
-import {RpcMethodOpt} from '@polkadot/jsonrpc/types';
+import { RpcMethodOpt } from '@polkadot/jsonrpc/types';
 
 import createMethod from '@polkadot/jsonrpc/create/method';
 import createParam from '@polkadot/jsonrpc/create/param';
@@ -42,8 +42,8 @@ const liquidityValue: RpcMethodOpt = {
 const section = 'cennzx';
 
 export default [
-  {...createMethod(section, 'buyPrice', buyPrice), name: 'buyPrice'},
-  {...createMethod(section, 'sellPrice', sellPrice), name: 'sellPrice'},
-  {...createMethod(section, 'liquidityPrice', liquidityPrice), name: 'liquidityPrice'},
-  {...createMethod(section, 'liquidityValue', liquidityValue), name: 'liquidityValue'},
+  { ...createMethod(section, 'buyPrice', buyPrice), name: 'buyPrice' },
+  { ...createMethod(section, 'sellPrice', sellPrice), name: 'sellPrice' },
+  { ...createMethod(section, 'liquidityPrice', liquidityPrice), name: 'liquidityPrice' },
+  { ...createMethod(section, 'liquidityValue', liquidityValue), name: 'liquidityValue' },
 ];

--- a/packages/api/src/rpc/genericAsset.ts
+++ b/packages/api/src/rpc/genericAsset.ts
@@ -1,4 +1,4 @@
-import {RpcMethodOpt} from '@polkadot/jsonrpc/types';
+import { RpcMethodOpt } from '@polkadot/jsonrpc/types';
 
 import createMethod from '@polkadot/jsonrpc/create/method';
 
@@ -11,4 +11,4 @@ const registeredAssets: RpcMethodOpt = {
 
 const section = 'genericAsset';
 
-export default [{...createMethod(section, 'registeredAssets', registeredAssets), name: 'registeredAssets'}];
+export default [{ ...createMethod(section, 'registeredAssets', registeredAssets), name: 'registeredAssets' }];

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Observable} from 'rxjs';
+import { Observable } from 'rxjs';
 
-import {DecoratedCennznetDerive} from '@cennznet/api/derives';
-import {ChargeTransactionPayment} from '@cennznet/types';
+import { DecoratedCennznetDerive } from '@cennznet/api/derives';
+import { ChargeTransactionPayment } from '@cennznet/types';
 import {
   Callback,
   Codec,
@@ -26,7 +26,7 @@ import {
   RegistryTypes,
   SignatureOptions,
 } from '@cennznet/types/types';
-import {DeriveCustom} from '@polkadot/api-derive';
+import { DeriveCustom } from '@polkadot/api-derive';
 import ApiBase from '@polkadot/api/base';
 import {
   ApiOptions as ApiOptionsBase,
@@ -38,11 +38,11 @@ import {
   SubmittableResultSubscription,
   UnsubscribePromise,
 } from '@polkadot/api/types';
-import {ProviderInterface} from '@polkadot/rpc-provider/types';
-import {u64} from '@polkadot/types';
-import {AccountId, Address, Hash} from '@polkadot/types/interfaces';
-import {StorageEntry} from '@polkadot/types/primitive/StorageKey';
-import {CallBase} from '@polkadot/types/types';
+import { ProviderInterface } from '@polkadot/rpc-provider/types';
+import { u64 } from '@polkadot/types';
+import { AccountId, Address, Hash } from '@polkadot/types/interfaces';
+import { StorageEntry } from '@polkadot/types/primitive/StorageKey';
+import { CallBase } from '@polkadot/types/types';
 
 export * from '@polkadot/api/types';
 export type ApiTypes = 'promise' | 'rxjs';

--- a/packages/api/src/util/derives.ts
+++ b/packages/api/src/util/derives.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DeriveCustom} from '@polkadot/api-derive';
+import { DeriveCustom } from '@polkadot/api-derive';
 
 export function mergeDeriveOptions(deriveOrigin: DeriveCustom, deriveAppend: DeriveCustom = {}): DeriveCustom {
-    const ret = {...deriveOrigin};
-    for (const [module, derives] of Object.entries(deriveAppend)) {
-        ret[module] = Object.assign({}, ret[module], derives);
-    }
-    return ret;
+  const ret = { ...deriveOrigin };
+  for (const [module, derives] of Object.entries(deriveAppend)) {
+    ret[module] = Object.assign({}, ret[module], derives);
+  }
+  return ret;
 }

--- a/packages/api/src/util/getProvider.ts
+++ b/packages/api/src/util/getProvider.ts
@@ -12,26 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assert} from '@cennznet/util';
-import {HttpProvider, WsProvider} from '@polkadot/rpc-provider';
-import {ProviderInterface} from '@polkadot/rpc-provider/types';
+import { assert } from '@cennznet/util';
+import { HttpProvider, WsProvider } from '@polkadot/rpc-provider';
+import { ProviderInterface } from '@polkadot/rpc-provider/types';
 
 const REGEX = /^(wss?|https?):\/\//;
 
 export function getProvider(providerString: string): ProviderInterface {
-    const providerStringLowerCase = providerString.toLowerCase();
+  const providerStringLowerCase = providerString.toLowerCase();
 
-    const group = REGEX.exec(providerStringLowerCase);
-    assert(group, `Missing protocol: ${providerString}`);
+  const group = REGEX.exec(providerStringLowerCase);
+  assert(group, `Missing protocol: ${providerString}`);
 
-    const protocol = group[1];
+  const protocol = group[1];
 
-    if (protocol === 'wss' || protocol === 'ws') {
-        return new WsProvider(providerStringLowerCase);
-    } else if (protocol === 'https' || protocol === 'http') {
-        return new HttpProvider(providerStringLowerCase);
-    }
+  if (protocol === 'wss' || protocol === 'ws') {
+    return new WsProvider(providerStringLowerCase);
+  } else if (protocol === 'https' || protocol === 'http') {
+    return new HttpProvider(providerStringLowerCase);
+  }
 
-    // All cases should be handled above, but if not, throw an error
-    throw new Error(`Invalid URL: ${providerString}`);
+  // All cases should be handled above, but if not, throw an error
+  throw new Error(`Invalid URL: ${providerString}`);
 }

--- a/packages/api/src/util/getTimeout.ts
+++ b/packages/api/src/util/getTimeout.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ProviderInterface} from '@polkadot/rpc-provider/types';
-import {isFunction, isObject} from '@polkadot/util';
-import {ApiOptions} from '../types';
+import { ProviderInterface } from '@polkadot/rpc-provider/types';
+import { isFunction, isObject } from '@polkadot/util';
+import { ApiOptions } from '../types';
 
 export function getTimeout(options: ApiOptions | ProviderInterface = {}): number {
-    return isObject(options) && isFunction((options as ProviderInterface).send)
-        ? undefined
-        : (options as ApiOptions).timeout;
+  return isObject(options) && isFunction((options as ProviderInterface).send)
+    ? undefined
+    : (options as ApiOptions).timeout;
 }

--- a/packages/api/src/util/injectPlugin.ts
+++ b/packages/api/src/util/injectPlugin.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {IPlugin} from '@cennznet/api/types';
-import {mergeDeriveOptions} from '@cennznet/api/util/derives';
-import {TypeRegistry} from '@polkadot/types';
-import {Api} from '../Api';
-import {ApiRx} from '../ApiRx';
-import {ApiOptions} from '../types';
+import { IPlugin } from '@cennznet/api/types';
+import { mergeDeriveOptions } from '@cennznet/api/util/derives';
+import { TypeRegistry } from '@polkadot/types';
+import { Api } from '../Api';
+import { ApiRx } from '../ApiRx';
+import { ApiOptions } from '../types';
 
 export function injectOption(options: ApiOptions, plugins: IPlugin[] = []): void {
   for (const plugin of plugins) {

--- a/packages/api/src/util/logging.ts
+++ b/packages/api/src/util/logging.ts
@@ -16,7 +16,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import {logger} from '@polkadot/util';
+import { logger } from '@polkadot/util';
 
 const l = logger('@cennznet/api');
 

--- a/packages/crml-attestation/src/Attestation.ts
+++ b/packages/crml-attestation/src/Attestation.ts
@@ -12,50 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Api} from '@cennznet/api';
-import {SubmittableExtrinsic} from '@cennznet/api/types';
-import {assert} from '@cennznet/util';
-import {QueryableGetClaim, QueryableGetClaimList, QueryableGetClaims} from './types';
+import { Api } from '@cennznet/api';
+import { SubmittableExtrinsic } from '@cennznet/api/types';
+import { assert } from '@cennznet/util';
+import { QueryableGetClaim, QueryableGetClaimList, QueryableGetClaims } from './types';
 
 export class Attestation {
-    private readonly _api: Api;
+  private readonly _api: Api;
 
-    constructor(api: Api) {
-        assert(
-            (api as any)._options.derives.attestation || ((api as any)._derive || {}).attestation,
-            "init attestation's derives first"
-        );
-        this._api = api;
-    }
+  constructor(api: Api) {
+    assert(
+      (api as any)._options.derives.attestation || ((api as any)._derive || {}).attestation,
+      "init attestation's derives first"
+    );
+    this._api = api;
+  }
 
-    get api(): Api {
-        return this._api;
-    }
+  get api(): Api {
+    return this._api;
+  }
 
-    setClaim(holder: string, topic: string, value: string | Uint8Array): SubmittableExtrinsic<'promise'> {
-        return this.api.tx.attestation.setClaim(holder, topic, value);
-    }
+  setClaim(holder: string, topic: string, value: string | Uint8Array): SubmittableExtrinsic<'promise'> {
+    return this.api.tx.attestation.setClaim(holder, topic, value);
+  }
 
-    setSelfClaim(topic: string, value: string | Uint8Array): SubmittableExtrinsic<'promise'> {
-        return this.api.tx.attestation.setSelfClaim(topic, value);
-    }
+  setSelfClaim(topic: string, value: string | Uint8Array): SubmittableExtrinsic<'promise'> {
+    return this.api.tx.attestation.setSelfClaim(topic, value);
+  }
 
-    removeClaim(holder: string, topic: string): SubmittableExtrinsic<'promise'> {
-        return this.api.tx.attestation.removeClaim(holder, topic);
-    }
+  removeClaim(holder: string, topic: string): SubmittableExtrinsic<'promise'> {
+    return this.api.tx.attestation.removeClaim(holder, topic);
+  }
 
-    get getClaim(): QueryableGetClaim {
-        return this.api.derive.attestation.getClaim;
-    }
+  get getClaim(): QueryableGetClaim {
+    return this.api.derive.attestation.getClaim;
+  }
 
-    /**
-     * @deprecated use getClaimList() instead
-     */
-    get getClaims(): QueryableGetClaims {
-        return this.api.derive.attestation.getClaims;
-    }
+  /**
+   * @deprecated use getClaimList() instead
+   */
+  get getClaims(): QueryableGetClaims {
+    return this.api.derive.attestation.getClaims;
+  }
 
-    get getClaimList(): QueryableGetClaimList {
-        return this.api.derive.attestation.claims;
-    }
+  get getClaimList(): QueryableGetClaimList {
+    return this.api.derive.attestation.claims;
+  }
 }

--- a/packages/crml-attestation/src/AttestationRx.ts
+++ b/packages/crml-attestation/src/AttestationRx.ts
@@ -12,51 +12,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiRx} from '@cennznet/api';
-import {SubmittableExtrinsic} from '@cennznet/api/types';
-import {assert} from '@cennznet/util';
+import { ApiRx } from '@cennznet/api';
+import { SubmittableExtrinsic } from '@cennznet/api/types';
+import { assert } from '@cennznet/util';
 
-import {QueryableGetClaimListRx, QueryableGetClaimRx, QueryableGetClaimsRx} from './types';
+import { QueryableGetClaimListRx, QueryableGetClaimRx, QueryableGetClaimsRx } from './types';
 
 export class AttestationRx {
-    private readonly _api: ApiRx;
+  private readonly _api: ApiRx;
 
-    constructor(api: ApiRx) {
-        assert(
-            (api as any)._options.derives.attestation || ((api as any)._derive || {}).attestation,
-            "init attestation's derives first"
-        );
-        this._api = api;
-    }
+  constructor(api: ApiRx) {
+    assert(
+      (api as any)._options.derives.attestation || ((api as any)._derive || {}).attestation,
+      "init attestation's derives first"
+    );
+    this._api = api;
+  }
 
-    get api(): ApiRx {
-        return this._api;
-    }
+  get api(): ApiRx {
+    return this._api;
+  }
 
-    setClaim(holder: string, topic: string, value: string | Uint8Array): SubmittableExtrinsic<'rxjs'> {
-        return this.api.tx.attestation.setClaim(holder, topic, value);
-    }
+  setClaim(holder: string, topic: string, value: string | Uint8Array): SubmittableExtrinsic<'rxjs'> {
+    return this.api.tx.attestation.setClaim(holder, topic, value);
+  }
 
-    setSelfClaim(topic: string, value: string | Uint8Array): SubmittableExtrinsic<'rxjs'> {
-        return this.api.tx.attestation.setSelfClaim(topic, value);
-    }
+  setSelfClaim(topic: string, value: string | Uint8Array): SubmittableExtrinsic<'rxjs'> {
+    return this.api.tx.attestation.setSelfClaim(topic, value);
+  }
 
-    removeClaim(holder: string, topic: string): SubmittableExtrinsic<'rxjs'> {
-        return this.api.tx.attestation.removeClaim(holder, topic);
-    }
+  removeClaim(holder: string, topic: string): SubmittableExtrinsic<'rxjs'> {
+    return this.api.tx.attestation.removeClaim(holder, topic);
+  }
 
-    get getClaim(): QueryableGetClaimRx {
-        return this.api.derive.attestation.getClaim;
-    }
+  get getClaim(): QueryableGetClaimRx {
+    return this.api.derive.attestation.getClaim;
+  }
 
-    /**
-     * @deprecated use getClaimList() instead
-     */
-    get getClaims(): QueryableGetClaimsRx {
-        return this.api.derive.attestation.getClaims;
-    }
+  /**
+   * @deprecated use getClaimList() instead
+   */
+  get getClaims(): QueryableGetClaimsRx {
+    return this.api.derive.attestation.getClaims;
+  }
 
-    get getClaimList(): QueryableGetClaimListRx {
-        return this.api.derive.attestation.claims;
-    }
+  get getClaimList(): QueryableGetClaimListRx {
+    return this.api.derive.attestation.claims;
+  }
 }

--- a/packages/crml-attestation/src/derives/claims.ts
+++ b/packages/crml-attestation/src/derives/claims.ts
@@ -12,34 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {combineLatest, Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { combineLatest, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
-import {Claim} from '../types';
-import {getClaim} from './getClaim';
+import { Claim } from '../types';
+import { getClaim } from './getClaim';
 
 export function claims(api: ApiInterfaceRx) {
-    return (holder: string, issuers: Array<string>, topics: Array<string>): Observable<Claim[]> => {
-        const observables = issuers.reduce(
-            (prev, issuer) => {
-                prev.push(
-                    ...topics.map(topic =>
-                        getClaim(api)(holder, issuer, topic).pipe(
-                            map(value => ({
-                                holder,
-                                issuer,
-                                topic,
-                                value,
-                            }))
-                        )
-                    )
-                );
-                return prev;
-            },
-            [] as Observable<Claim>[]
-        );
+  return (holder: string, issuers: Array<string>, topics: Array<string>): Observable<Claim[]> => {
+    const observables = issuers.reduce((prev, issuer) => {
+      prev.push(
+        ...topics.map(topic =>
+          getClaim(api)(holder, issuer, topic).pipe(
+            map(value => ({
+              holder,
+              issuer,
+              topic,
+              value,
+            }))
+          )
+        )
+      );
+      return prev;
+    }, [] as Observable<Claim>[]);
 
-        return combineLatest(observables);
-    };
+    return combineLatest(observables);
+  };
 }

--- a/packages/crml-attestation/src/derives/getClaim.ts
+++ b/packages/crml-attestation/src/derives/getClaim.ts
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {AttestationValue} from '@cennznet/types';
-import {drr} from '@polkadot/rpc-core/rxjs';
-import {Observable} from 'rxjs';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { AttestationValue } from '@cennznet/types';
+import { drr } from '@polkadot/rpc-core/rxjs';
+import { Observable } from 'rxjs';
 
 export function getClaim(api: ApiInterfaceRx) {
   return (holder: string, issuer: string, topic: string): Observable<AttestationValue> =>

--- a/packages/crml-attestation/src/derives/getClaims.ts
+++ b/packages/crml-attestation/src/derives/getClaims.ts
@@ -12,31 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {AttestationValue} from '@cennznet/types';
-import {combineLatest, Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
-import {Claim, Claims, ClaimsAsHexFunc, ClaimsAsU8aFunc, ClaimsObject} from '../types';
-import {getClaim} from './getClaim';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { AttestationValue } from '@cennznet/types';
+import { combineLatest, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Claim, Claims, ClaimsAsHexFunc, ClaimsAsU8aFunc, ClaimsObject } from '../types';
+import { getClaim } from './getClaim';
 
 export const claimsMapper = (
-    valueMapper: (value: AttestationValue) => string | Uint8Array,
-    claims: Claims
+  valueMapper: (value: AttestationValue) => string | Uint8Array,
+  claims: Claims
 ): ClaimsAsHexFunc | ClaimsAsU8aFunc => () => {
-    const res = {};
-    const topics = Object.keys(claims);
+  const res = {};
+  const topics = Object.keys(claims);
 
-    topics.forEach(topic => {
-        res[topic] = {};
-        const issuers = Object.keys(claims[topic]);
+  topics.forEach(topic => {
+    res[topic] = {};
+    const issuers = Object.keys(claims[topic]);
 
-        issuers.forEach(issuer => {
-            const value = claims[topic][issuer];
-            res[topic][issuer] = valueMapper(value);
-        });
+    issuers.forEach(issuer => {
+      const value = claims[topic][issuer];
+      res[topic][issuer] = valueMapper(value);
     });
+  });
 
-    return res;
+  return res;
 };
 
 /**
@@ -44,44 +44,44 @@ export const claimsMapper = (
  * @param api
  */
 export function getClaims(api: ApiInterfaceRx) {
-    return (holder: string, issuers: Array<string>, topics: Array<string>): Observable<ClaimsObject> => {
-        const stream = getClaim(api);
+  return (holder: string, issuers: Array<string>, topics: Array<string>): Observable<ClaimsObject> => {
+    const stream = getClaim(api);
 
-        const observables: Array<Observable<Claim>> = issuers.reduce((prev, issuer) => {
-            return [
-                ...prev,
-                ...topics.map(topic =>
-                    stream(holder, issuer, topic).pipe(
-                        map(value => ({
-                            holder,
-                            issuer,
-                            topic,
-                            value,
-                        }))
-                    )
-                ),
-            ];
-        }, []);
+    const observables: Array<Observable<Claim>> = issuers.reduce((prev, issuer) => {
+      return [
+        ...prev,
+        ...topics.map(topic =>
+          stream(holder, issuer, topic).pipe(
+            map(value => ({
+              holder,
+              issuer,
+              topic,
+              value,
+            }))
+          )
+        ),
+      ];
+    }, []);
 
-        return combineLatest(observables).pipe(
-            map(claimsArray => {
-                const claims: Claims = claimsArray.reduce((prev, claim) => {
-                    const {topic, issuer, value} = claim;
+    return combineLatest(observables).pipe(
+      map(claimsArray => {
+        const claims: Claims = claimsArray.reduce((prev, claim) => {
+          const { topic, issuer, value } = claim;
 
-                    if (!prev[topic]) {
-                        prev[topic] = {};
-                    }
+          if (!prev[topic]) {
+            prev[topic] = {};
+          }
 
-                    prev[topic][issuer] = value;
-                    return prev;
-                }, {});
+          prev[topic][issuer] = value;
+          return prev;
+        }, {});
 
-                return {
-                    claims,
-                    claimsAsHex: claimsMapper(value => value.toHex(), claims) as ClaimsAsHexFunc,
-                    claimsAsU8a: claimsMapper(value => value.toU8a(), claims) as ClaimsAsU8aFunc,
-                };
-            })
-        );
-    };
+        return {
+          claims,
+          claimsAsHex: claimsMapper(value => value.toHex(), claims) as ClaimsAsHexFunc,
+          claimsAsU8a: claimsMapper(value => value.toU8a(), claims) as ClaimsAsU8aFunc,
+        };
+      })
+    );
+  };
 }

--- a/packages/crml-attestation/src/derives/index.ts
+++ b/packages/crml-attestation/src/derives/index.ts
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {getClaim} from './getClaim';
-export {getClaims} from './getClaims';
-export {claims} from './claims';
+export { getClaim } from './getClaim';
+export { getClaims } from './getClaims';
+export { claims } from './claims';

--- a/packages/crml-attestation/src/index.ts
+++ b/packages/crml-attestation/src/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {Attestation} from './Attestation';
-export {AttestationRx} from './AttestationRx';
+export { Attestation } from './Attestation';
+export { AttestationRx } from './AttestationRx';
 
-export {default as Plugin} from './plugin';
+export { default as Plugin } from './plugin';

--- a/packages/crml-attestation/src/plugin.ts
+++ b/packages/crml-attestation/src/plugin.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {IPlugin} from '@cennznet/api/types';
-import {Attestation} from './Attestation';
-import {AttestationRx} from './AttestationRx';
+import { IPlugin } from '@cennznet/api/types';
+import { Attestation } from './Attestation';
+import { AttestationRx } from './AttestationRx';
 // @ts-ignore
 export default {
   injectName: 'attestation',

--- a/packages/crml-attestation/src/types.ts
+++ b/packages/crml-attestation/src/types.ts
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AttestationValue} from '@cennznet/types';
-import {Observable} from 'rxjs';
+import { AttestationValue } from '@cennznet/types';
+import { Observable } from 'rxjs';
 
-export type Claim = {holder: string; issuer: string; topic: string; value: AttestationValue};
+export type Claim = { holder: string; issuer: string; topic: string; value: AttestationValue };
 
 /**
  * @deprecated
  */
-export type Claims = {[topic: string]: {[issuers: string]: AttestationValue}};
+export type Claims = { [topic: string]: { [issuers: string]: AttestationValue } };
 /**
  * @deprecated
  */
-export type ClaimsAsHex = {[topic: string]: {[issuers: string]: string}};
+export type ClaimsAsHex = { [topic: string]: { [issuers: string]: string } };
 /**
  * @deprecated
  */
-export type ClaimsAsU8a = {[topic: string]: {[issuers: string]: Uint8Array}};
+export type ClaimsAsU8a = { [topic: string]: { [issuers: string]: Uint8Array } };
 /**
  * @deprecated
  */
@@ -42,40 +42,40 @@ export type ClaimsAsU8aFunc = () => ClaimsAsU8a;
  * @deprecated
  */
 export type ClaimsObject = {
-    claims: Claims;
-    claimsAsHex: ClaimsAsHexFunc;
-    claimsAsU8a: ClaimsAsU8aFunc;
+  claims: Claims;
+  claimsAsHex: ClaimsAsHexFunc;
+  claimsAsU8a: ClaimsAsU8aFunc;
 };
 
 export interface QueryableGetClaim {
-    (holder: string, issuer: string, topic: string): Promise<AttestationValue>;
-    (holder: string, issuer: string, topic: string, callbackFn: any): Promise<() => any>;
+  (holder: string, issuer: string, topic: string): Promise<AttestationValue>;
+  (holder: string, issuer: string, topic: string, callbackFn: any): Promise<() => any>;
 }
 
 export interface QueryableGetClaimList {
-    (holder: string, issuers: Array<string>, topic: Array<string>): Promise<Claim[]>;
-    (holder: string, issuers: Array<string>, topic: Array<string>, callbackFn: any): Promise<() => void>;
+  (holder: string, issuers: Array<string>, topic: Array<string>): Promise<Claim[]>;
+  (holder: string, issuers: Array<string>, topic: Array<string>, callbackFn: any): Promise<() => void>;
 }
 
 /**
  * @deprecated
  */
 export interface QueryableGetClaims {
-    (holder: string, issuers: Array<string>, topic: Array<string>): Promise<ClaimsObject>;
-    (holder: string, issuers: Array<string>, topic: Array<string>, callbackFn: any): Promise<() => void>;
+  (holder: string, issuers: Array<string>, topic: Array<string>): Promise<ClaimsObject>;
+  (holder: string, issuers: Array<string>, topic: Array<string>, callbackFn: any): Promise<() => void>;
 }
 
 export interface QueryableGetClaimRx {
-    (holder: string, issuer: string, topic: string): Observable<AttestationValue>;
+  (holder: string, issuer: string, topic: string): Observable<AttestationValue>;
 }
 
 export interface QueryableGetClaimListRx {
-    (holder: string, issuers: Array<string>, topic: Array<string>): Observable<Claim[]>;
+  (holder: string, issuers: Array<string>, topic: Array<string>): Observable<Claim[]>;
 }
 
 /**
  * @deprecated
  */
 export interface QueryableGetClaimsRx {
-    (holder: string, issuers: Array<string>, topic: Array<string>): Observable<ClaimsObject>;
+  (holder: string, issuers: Array<string>, topic: Array<string>): Observable<ClaimsObject>;
 }

--- a/packages/crml-cennzx-spot/src/CennzxSpot.ts
+++ b/packages/crml-cennzx-spot/src/CennzxSpot.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Api} from '@cennznet/api';
-import {QueryableStorageEntry, SubmittableExtrinsic} from '@cennznet/api/types';
-import {AssetId} from '@cennznet/types';
-import {AnyAddress, AnyAssetId, AnyNumber} from '@cennznet/types/types';
-import {assert} from '@cennznet/util';
+import { Api } from '@cennznet/api';
+import { QueryableStorageEntry, SubmittableExtrinsic } from '@cennznet/api/types';
+import { AssetId } from '@cennznet/types';
+import { AnyAddress, AnyAssetId, AnyNumber } from '@cennznet/types/types';
+import { assert } from '@cennznet/util';
 import {
   QueryableGetAssetWithdrawn,
   QueryableGetLiquidityBalance,

--- a/packages/crml-cennzx-spot/src/CennzxSpotRx.ts
+++ b/packages/crml-cennzx-spot/src/CennzxSpotRx.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiRx} from '@cennznet/api';
-import {QueryableStorageEntry, SubmittableExtrinsic} from '@cennznet/api/types';
-import {AssetId} from '@cennznet/types';
-import {AnyAddress, AnyAssetId, AnyNumber} from '@cennznet/types/types';
-import {assert} from '@cennznet/util';
+import { ApiRx } from '@cennznet/api';
+import { QueryableStorageEntry, SubmittableExtrinsic } from '@cennznet/api/types';
+import { AssetId } from '@cennznet/types';
+import { AnyAddress, AnyAssetId, AnyNumber } from '@cennznet/types/types';
+import { assert } from '@cennznet/util';
 import {
   QueryableGetAssetWithdrawnRx,
   QueryableGetLiquidityBalancePriceRx,

--- a/packages/crml-cennzx-spot/src/derives/assetWithdrawn.ts
+++ b/packages/crml-cennzx-spot/src/derives/assetWithdrawn.ts
@@ -12,50 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {AnyAssetId, AnyNumber} from '@cennznet/types/types';
-import {Hash} from '@polkadot/types/interfaces';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { AnyAssetId, AnyNumber } from '@cennznet/types/types';
+import { Hash } from '@polkadot/types/interfaces';
 import BN from 'bn.js';
-import {combineLatest, Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
-import {getAssetToWithdraw} from '../utils/utils';
-import {poolAssetBalance, poolAssetBalanceAt, poolCoreAssetBalance, poolCoreAssetBalanceAt} from './poolBalance';
-import {totalLiquidity, totalLiquidityAt} from './totalLiquidity';
+import { combineLatest, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { getAssetToWithdraw } from '../utils/utils';
+import { poolAssetBalance, poolAssetBalanceAt, poolCoreAssetBalance, poolCoreAssetBalanceAt } from './poolBalance';
+import { totalLiquidity, totalLiquidityAt } from './totalLiquidity';
 
 export function assetToWithdraw(api: ApiInterfaceRx) {
-    return (assetId: AnyAssetId, liquidity: AnyNumber): Observable<{coreAmount: BN; assetAmount: BN}> => {
-        return combineLatest([
-            poolAssetBalance(api)(assetId),
-            poolCoreAssetBalance(api)(assetId),
-            totalLiquidity(api)(assetId),
-        ]).pipe(
-            map(([tradeAssetReserve, coreAssetReserve, totalLiquidity]) =>
-                getAssetToWithdraw(
-                    new BN(liquidity),
-                    coreAssetReserve as any,
-                    tradeAssetReserve as any,
-                    totalLiquidity as any
-                )
-            )
-        );
-    };
+  return (assetId: AnyAssetId, liquidity: AnyNumber): Observable<{ coreAmount: BN; assetAmount: BN }> => {
+    return combineLatest([
+      poolAssetBalance(api)(assetId),
+      poolCoreAssetBalance(api)(assetId),
+      totalLiquidity(api)(assetId),
+    ]).pipe(
+      map(([tradeAssetReserve, coreAssetReserve, totalLiquidity]) =>
+        getAssetToWithdraw(new BN(liquidity), coreAssetReserve as any, tradeAssetReserve as any, totalLiquidity as any)
+      )
+    );
+  };
 }
 
 export function assetToWithdrawAt(api: ApiInterfaceRx) {
-    return (hash: Hash, assetId: AnyAssetId, liquidity: AnyNumber): Observable<{coreAmount: BN; assetAmount: BN}> => {
-        return combineLatest([
-            poolAssetBalanceAt(api)(hash, assetId),
-            poolCoreAssetBalanceAt(api)(hash, assetId),
-            totalLiquidityAt(api)(hash, assetId),
-        ]).pipe(
-            map(([tradeAssetReserve, coreAssetReserve, totalLiquidity]) =>
-                getAssetToWithdraw(
-                    new BN(liquidity),
-                    coreAssetReserve as any,
-                    tradeAssetReserve as any,
-                    totalLiquidity as any
-                )
-            )
-        );
-    };
+  return (hash: Hash, assetId: AnyAssetId, liquidity: AnyNumber): Observable<{ coreAmount: BN; assetAmount: BN }> => {
+    return combineLatest([
+      poolAssetBalanceAt(api)(hash, assetId),
+      poolCoreAssetBalanceAt(api)(hash, assetId),
+      totalLiquidityAt(api)(hash, assetId),
+    ]).pipe(
+      map(([tradeAssetReserve, coreAssetReserve, totalLiquidity]) =>
+        getAssetToWithdraw(new BN(liquidity), coreAssetReserve as any, tradeAssetReserve as any, totalLiquidity as any)
+      )
+    );
+  };
 }

--- a/packages/crml-cennzx-spot/src/derives/exchangeAddress.ts
+++ b/packages/crml-cennzx-spot/src/derives/exchangeAddress.ts
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {AnyAssetId} from '@cennznet/types/types';
-import {drr} from '@polkadot/rpc-core/rxjs';
-import {Observable} from 'rxjs';
-import {first, map} from 'rxjs/operators';
-import {generateExchangeAddress} from '../utils/utils';
-import {coreAssetId} from './shared';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { AnyAssetId } from '@cennznet/types/types';
+import { drr } from '@polkadot/rpc-core/rxjs';
+import { Observable } from 'rxjs';
+import { first, map } from 'rxjs/operators';
+import { generateExchangeAddress } from '../utils/utils';
+import { coreAssetId } from './shared';
 
 export function exchangeAddress(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId): Observable<string> =>

--- a/packages/crml-cennzx-spot/src/derives/index.ts
+++ b/packages/crml-cennzx-spot/src/derives/index.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {liquidityBalance, liquidityBalanceAt} from './liquidityBalance';
-export {totalLiquidity, totalLiquidityAt} from './totalLiquidity';
-export {exchangeAddress} from './exchangeAddress';
-export {poolAssetBalance, poolCoreAssetBalance, poolAssetBalanceAt, poolCoreAssetBalanceAt} from './poolBalance';
-export {assetToWithdraw, assetToWithdrawAt} from './assetWithdrawn';
+export { liquidityBalance, liquidityBalanceAt } from './liquidityBalance';
+export { totalLiquidity, totalLiquidityAt } from './totalLiquidity';
+export { exchangeAddress } from './exchangeAddress';
+export { poolAssetBalance, poolCoreAssetBalance, poolAssetBalanceAt, poolCoreAssetBalanceAt } from './poolBalance';
+export { assetToWithdraw, assetToWithdrawAt } from './assetWithdrawn';

--- a/packages/crml-cennzx-spot/src/derives/liquidityBalance.ts
+++ b/packages/crml-cennzx-spot/src/derives/liquidityBalance.ts
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {AnyAddress, AnyAssetId} from '@cennznet/types/types';
-import {drr} from '@polkadot/rpc-core/rxjs';
-import {Balance, Hash} from '@polkadot/types/interfaces';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { AnyAddress, AnyAssetId } from '@cennznet/types/types';
+import { drr } from '@polkadot/rpc-core/rxjs';
+import { Balance, Hash } from '@polkadot/types/interfaces';
 import BN from 'bn.js';
-import {Observable} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
-import {getExchangeKey} from '../utils/utils';
-import {coreAssetId, coreAssetIdAt} from './shared';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { getExchangeKey } from '../utils/utils';
+import { coreAssetId, coreAssetIdAt } from './shared';
 
 export function liquidityBalance(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId, address: AnyAddress): Observable<BN> => {

--- a/packages/crml-cennzx-spot/src/derives/poolBalance.ts
+++ b/packages/crml-cennzx-spot/src/derives/poolBalance.ts
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {AnyAssetId} from '@cennznet/types/types';
-import {drr} from '@polkadot/rpc-core/rxjs';
-import {Hash} from '@polkadot/types/interfaces';
-import {combineLatest, Observable} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
-import {exchangeAddress} from './exchangeAddress';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { AnyAssetId } from '@cennznet/types/types';
+import { drr } from '@polkadot/rpc-core/rxjs';
+import { Hash } from '@polkadot/types/interfaces';
+import { combineLatest, Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { exchangeAddress } from './exchangeAddress';
 
 export function poolAssetBalance(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId): Observable<any> => {

--- a/packages/crml-cennzx-spot/src/derives/shared.ts
+++ b/packages/crml-cennzx-spot/src/derives/shared.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {AssetId} from '@cennznet/types';
-import {drr} from '@polkadot/rpc-core/rxjs';
-import {Hash, Permill} from '@polkadot/types/interfaces';
-import {Observable} from 'rxjs';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { AssetId } from '@cennznet/types';
+import { drr } from '@polkadot/rpc-core/rxjs';
+import { Hash, Permill } from '@polkadot/types/interfaces';
+import { Observable } from 'rxjs';
 
 export function coreAssetId(api: ApiInterfaceRx) {
   return (): Observable<AssetId> => api.query.cennzxSpot.coreAssetId().pipe(drr()) as Observable<AssetId>;

--- a/packages/crml-cennzx-spot/src/derives/totalLiquidity.ts
+++ b/packages/crml-cennzx-spot/src/derives/totalLiquidity.ts
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiInterfaceRx} from '@cennznet/api/types';
-import {AnyAssetId} from '@cennznet/types/types';
-import {Hash} from '@polkadot/types/interfaces';
+import { ApiInterfaceRx } from '@cennznet/api/types';
+import { AnyAssetId } from '@cennznet/types/types';
+import { Hash } from '@polkadot/types/interfaces';
 import BN from 'bn.js';
-import {Observable} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
-import {getExchangeKey} from '../utils/utils';
-import {coreAssetId, coreAssetIdAt} from './shared';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { getExchangeKey } from '../utils/utils';
+import { coreAssetId, coreAssetIdAt } from './shared';
 
 export function totalLiquidity(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId): Observable<BN> => {

--- a/packages/crml-cennzx-spot/src/index.ts
+++ b/packages/crml-cennzx-spot/src/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {CennzxSpot} from './CennzxSpot';
-export {CennzxSpotRx} from './CennzxSpotRx';
+export { CennzxSpot } from './CennzxSpot';
+export { CennzxSpotRx } from './CennzxSpotRx';
 
-export {default as Plugin} from './plugin';
+export { default as Plugin } from './plugin';

--- a/packages/crml-cennzx-spot/src/plugin.ts
+++ b/packages/crml-cennzx-spot/src/plugin.ts
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {CennzxSpot} from './CennzxSpot';
-import {CennzxSpotRx} from './CennzxSpotRx';
+import { CennzxSpot } from './CennzxSpot';
+import { CennzxSpotRx } from './CennzxSpotRx';
 // import * as derives from './derives';
 
 export default {
-    injectName: 'cennzxSpot',
-    sdkClass: CennzxSpot,
-    sdkRxClass: CennzxSpotRx,
-    types: {},
-    derives: {
-        // cennzxSpot: derives,
-    },
+  injectName: 'cennzxSpot',
+  sdkClass: CennzxSpot,
+  sdkRxClass: CennzxSpotRx,
+  types: {},
+  derives: {
+    // cennzxSpot: derives,
+  },
 };

--- a/packages/crml-cennzx-spot/src/types.ts
+++ b/packages/crml-cennzx-spot/src/types.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AnyAddress, AnyAssetId, AnyNumber, IHash} from '@cennznet/types/types';
+import { AnyAddress, AnyAssetId, AnyNumber, IHash } from '@cennznet/types/types';
 import BN from 'bn.js';
-import {Observable} from 'rxjs';
+import { Observable } from 'rxjs';
 
 export interface QueryableGetLiquidityBalance {
   (assetId: AnyAssetId, address: AnyAddress): Promise<BN>;
@@ -73,17 +73,17 @@ export interface QueryableGetLiquidityBalancePriceRx {
 }
 
 export interface QueryableGetAssetWithdrawn {
-  (assetId: AnyAssetId, coreAmount: AnyNumber): Promise<{coreAmount: BN; assetAmount: BN}>;
+  (assetId: AnyAssetId, coreAmount: AnyNumber): Promise<{ coreAmount: BN; assetAmount: BN }>;
 
-  (assetId: AnyAssetId, coreAmount: AnyNumber, cb: (res: {coreAmount: BN; assetAmount: BN}) => void): Promise<
+  (assetId: AnyAssetId, coreAmount: AnyNumber, cb: (res: { coreAmount: BN; assetAmount: BN }) => void): Promise<
     () => any
   >;
 
-  at(hash: IHash, assetId: AnyAssetId, coreAmount: AnyNumber): Promise<{coreAmount: BN; assetAmount: BN}>;
+  at(hash: IHash, assetId: AnyAssetId, coreAmount: AnyNumber): Promise<{ coreAmount: BN; assetAmount: BN }>;
 }
 
 export interface QueryableGetAssetWithdrawnRx {
-  (assetId: AnyAssetId, coreAmount: AnyNumber): Observable<{coreAmount: BN; assetAmount: BN}>;
+  (assetId: AnyAssetId, coreAmount: AnyNumber): Observable<{ coreAmount: BN; assetAmount: BN }>;
 
-  at(hash: IHash, assetId: AnyAssetId, coreAmount: AnyNumber): Observable<{coreAmount: BN; assetAmount: BN}>;
+  at(hash: IHash, assetId: AnyAssetId, coreAmount: AnyNumber): Observable<{ coreAmount: BN; assetAmount: BN }>;
 }

--- a/packages/crml-cennzx-spot/src/utils/utils.ts
+++ b/packages/crml-cennzx-spot/src/utils/utils.ts
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AssetId, createType, Tuple, u64} from '@cennznet/types';
-import {AnyAssetId, AnyNumber} from '@cennznet/types/types';
-import {blake2AsU8a, stringToU8a, u8aConcat} from '@cennznet/util';
-import {Registry} from '@polkadot/types/types';
+import { AssetId, createType, Tuple, u64 } from '@cennznet/types';
+import { AnyAssetId, AnyNumber } from '@cennznet/types/types';
+import { blake2AsU8a, stringToU8a, u8aConcat } from '@cennznet/util';
+import { Registry } from '@polkadot/types/types';
 import BN from 'bn.js';
 
-import {MAX_U128, PERMILL_BASE, ROUND_UP} from '../constants';
+import { MAX_U128, PERMILL_BASE, ROUND_UP } from '../constants';
 
 /**
  * Generate the key of the balance storage
@@ -51,5 +51,5 @@ export function getAssetToWithdraw(liquidity: BN, coreReserve: BN, assetReserve:
   }
   const coreAmount = liquidity.mul(coreReserve).div(totalLiquidity);
   const assetAmount = liquidity.mul(assetReserve).div(totalLiquidity);
-  return {coreAmount, assetAmount};
+  return { coreAmount, assetAmount };
 }

--- a/packages/crml-generic-asset/src/GenericAsset.ts
+++ b/packages/crml-generic-asset/src/GenericAsset.ts
@@ -12,113 +12,113 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Api} from '@cennznet/api';
-import {QueryableStorageEntry, SubmittableExtrinsic} from '@cennznet/api/types';
-import {AssetId} from '@cennznet/types';
-import {AnyAddress, AnyAssetId, AnyNumber} from '@cennznet/types/types';
-import {assert} from '@cennznet/util';
-import {Balance} from '@polkadot/types/interfaces';
-import {AssetOptionsValue, QueryableGetBalance} from './types';
+import { Api } from '@cennznet/api';
+import { QueryableStorageEntry, SubmittableExtrinsic } from '@cennznet/api/types';
+import { AssetId } from '@cennznet/types';
+import { AnyAddress, AnyAssetId, AnyNumber } from '@cennznet/types/types';
+import { assert } from '@cennznet/util';
+import { Balance } from '@polkadot/types/interfaces';
+import { AssetOptionsValue, QueryableGetBalance } from './types';
 
 export class GenericAsset {
-    private _api: Api;
+  private _api: Api;
 
-    constructor(api: Api) {
-        assert(
-            (api as any)._options.derives.genericAsset || ((api as any)._derive || {}).genericAsset,
-            "init generic asset's derives first"
-        );
-        this._api = api;
-    }
+  constructor(api: Api) {
+    assert(
+      (api as any)._options.derives.genericAsset || ((api as any)._derive || {}).genericAsset,
+      "init generic asset's derives first"
+    );
+    this._api = api;
+  }
 
-    get api(): Api {
-        return this._api;
-    }
+  get api(): Api {
+    return this._api;
+  }
 
-    /**
-     * Create an asset
-     * @param options Initialization options of an asset
-     */
-    create(options: AssetOptionsValue): SubmittableExtrinsic<'promise'> {
-        return this.api.tx.genericAsset.create(options);
-    }
+  /**
+   * Create an asset
+   * @param options Initialization options of an asset
+   */
+  create(options: AssetOptionsValue): SubmittableExtrinsic<'promise'> {
+    return this.api.tx.genericAsset.create(options);
+  }
 
-    /**
-     * Transfer asset to the destination account
-     * @param assetId The id or symbol (for reserved asset) of the transferred asset
-     * @param dest The address of the destination account
-     * @param amount The amount to be transferred
-     */
-    transfer(assetId: AnyAssetId, dest: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'promise'> {
-        return this.api.tx.genericAsset.transfer(assetId, dest, amount);
-    }
+  /**
+   * Transfer asset to the destination account
+   * @param assetId The id or symbol (for reserved asset) of the transferred asset
+   * @param dest The address of the destination account
+   * @param amount The amount to be transferred
+   */
+  transfer(assetId: AnyAssetId, dest: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'promise'> {
+    return this.api.tx.genericAsset.transfer(assetId, dest, amount);
+  }
 
-    /**
-     * Mint asset to the destination account
-     * @param assetId The ID or symbol (for reserved asset) of the asset to be minted
-     * @param destination The address of the destination account
-     * @param amount The amount to be minted
-     */
-    mint(assetId: AnyAssetId, destination: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'promise'> {
-        return this.api.tx.genericAsset.mint(assetId, destination, amount);
-    }
+  /**
+   * Mint asset to the destination account
+   * @param assetId The ID or symbol (for reserved asset) of the asset to be minted
+   * @param destination The address of the destination account
+   * @param amount The amount to be minted
+   */
+  mint(assetId: AnyAssetId, destination: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'promise'> {
+    return this.api.tx.genericAsset.mint(assetId, destination, amount);
+  }
 
-    /**
-     * Burn asset from the source account
-     * @param assetId The ID or symbol (for reserved asset) of the asset to be minted
-     * @param source The address of the source account
-     * @param amount The amount to be burned
-     */
-    burn(assetId: AnyAssetId, source: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'promise'> {
-        return this.api.tx.genericAsset.burn(assetId, source, amount);
-    }
+  /**
+   * Burn asset from the source account
+   * @param assetId The ID or symbol (for reserved asset) of the asset to be minted
+   * @param source The address of the source account
+   * @param amount The amount to be burned
+   */
+  burn(assetId: AnyAssetId, source: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'promise'> {
+    return this.api.tx.genericAsset.burn(assetId, source, amount);
+  }
 
-    /**
-     * Query the next available asset ID
-     */
-    get getNextAssetId(): QueryableStorageEntry<'promise', AssetId> {
-        return this.api.query.genericAsset.nextAssetId as any;
-    }
+  /**
+   * Query the next available asset ID
+   */
+  get getNextAssetId(): QueryableStorageEntry<'promise', AssetId> {
+    return this.api.query.genericAsset.nextAssetId as any;
+  }
 
-    /**
-     * Query the total issuance of an asset
-     * @return a QueryableStorageFunction that needs a argument assetId
-     * @param assetId id or symbol (for reserved asset) of the asset
-     */
-    get getTotalIssuance(): QueryableStorageEntry<'promise', Balance> {
-        return this.api.query.genericAsset.totalIssuance as any;
-    }
+  /**
+   * Query the total issuance of an asset
+   * @return a QueryableStorageFunction that needs a argument assetId
+   * @param assetId id or symbol (for reserved asset) of the asset
+   */
+  get getTotalIssuance(): QueryableStorageEntry<'promise', Balance> {
+    return this.api.query.genericAsset.totalIssuance as any;
+  }
 
-    // tslint:disable:member-ordering
-    /**
-     * Query free balance of an asset for an account
-     * @param assetId The id or symbol (for reserved asset) of the asset
-     * @param address The address of the account
-     */
-    get getFreeBalance(): QueryableStorageEntry<'promise', Balance> {
-        return this.api.query.genericAsset.freeBalance as any;
-    }
+  // tslint:disable:member-ordering
+  /**
+   * Query free balance of an asset for an account
+   * @param assetId The id or symbol (for reserved asset) of the asset
+   * @param address The address of the account
+   */
+  get getFreeBalance(): QueryableStorageEntry<'promise', Balance> {
+    return this.api.query.genericAsset.freeBalance as any;
+  }
 
-    /**
-     * Query reserved balance of an asset for an account
-     * @param assetId The id or symbol (for reserved asset) of the asset
-     * @param address The address of the account
-     */
-    get getReservedBalance(): QueryableStorageEntry<'promise', Balance> {
-        return this.api.query.genericAsset.reservedBalance as any;
-    }
+  /**
+   * Query reserved balance of an asset for an account
+   * @param assetId The id or symbol (for reserved asset) of the asset
+   * @param address The address of the account
+   */
+  get getReservedBalance(): QueryableStorageEntry<'promise', Balance> {
+    return this.api.query.genericAsset.reservedBalance as any;
+  }
 
-    /**
-     * Query total balance of an asset for an account
-     * @param assetId The id or symbol (for reserved asset) of the asset
-     * @param address The address of the account
-     */
-    get getTotalBalance(): QueryableGetBalance {
-        const _fn = this.api.derive.genericAsset.totalBalance as QueryableGetBalance;
-        _fn.at = this.api.derive.genericAsset.totalBalanceAt;
+  /**
+   * Query total balance of an asset for an account
+   * @param assetId The id or symbol (for reserved asset) of the asset
+   * @param address The address of the account
+   */
+  get getTotalBalance(): QueryableGetBalance {
+    const _fn = this.api.derive.genericAsset.totalBalance as QueryableGetBalance;
+    _fn.at = this.api.derive.genericAsset.totalBalanceAt;
 
-        return _fn;
-    }
+    return _fn;
+  }
 
-    // tslint:enable:member-ordering
+  // tslint:enable:member-ordering
 }

--- a/packages/crml-generic-asset/src/GenericAssetRx.ts
+++ b/packages/crml-generic-asset/src/GenericAssetRx.ts
@@ -12,113 +12,113 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ApiRx} from '@cennznet/api';
-import {QueryableStorageEntry, SubmittableExtrinsic} from '@cennznet/api/types';
-import {AssetId} from '@cennznet/types';
-import {AnyAddress, AnyAssetId, AnyNumber} from '@cennznet/types/types';
-import {assert} from '@cennznet/util';
-import {Balance} from '@polkadot/types/interfaces';
-import {AssetOptionsValue, QueryableGetBalanceRx} from './types';
+import { ApiRx } from '@cennznet/api';
+import { QueryableStorageEntry, SubmittableExtrinsic } from '@cennznet/api/types';
+import { AssetId } from '@cennznet/types';
+import { AnyAddress, AnyAssetId, AnyNumber } from '@cennznet/types/types';
+import { assert } from '@cennznet/util';
+import { Balance } from '@polkadot/types/interfaces';
+import { AssetOptionsValue, QueryableGetBalanceRx } from './types';
 
 export class GenericAssetRx {
-    private _api: ApiRx;
+  private _api: ApiRx;
 
-    constructor(api: ApiRx) {
-        assert(
-            (api as any)._options.derives.genericAsset || ((api as any)._derive || {}).genericAsset,
-            "init generic asset's derives first"
-        );
-        this._api = api;
-    }
+  constructor(api: ApiRx) {
+    assert(
+      (api as any)._options.derives.genericAsset || ((api as any)._derive || {}).genericAsset,
+      "init generic asset's derives first"
+    );
+    this._api = api;
+  }
 
-    get api(): ApiRx {
-        return this._api;
-    }
+  get api(): ApiRx {
+    return this._api;
+  }
 
-    /**
-     * Create an asset
-     * @param options Initialization options of an asset
-     */
-    create(options: AssetOptionsValue): SubmittableExtrinsic<'rxjs'> {
-        return this.api.tx.genericAsset.create(options);
-    }
+  /**
+   * Create an asset
+   * @param options Initialization options of an asset
+   */
+  create(options: AssetOptionsValue): SubmittableExtrinsic<'rxjs'> {
+    return this.api.tx.genericAsset.create(options);
+  }
 
-    /**
-     * Transfer asset to the destination account
-     * @param assetId The id or symbol (for reserved asset) of the transferred asset
-     * @param dest The address of the destination account
-     * @param amount The amount to be transferred
-     */
-    transfer(assetId: AnyAssetId, dest: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'rxjs'> {
-        return this.api.tx.genericAsset.transfer(assetId, dest, amount);
-    }
+  /**
+   * Transfer asset to the destination account
+   * @param assetId The id or symbol (for reserved asset) of the transferred asset
+   * @param dest The address of the destination account
+   * @param amount The amount to be transferred
+   */
+  transfer(assetId: AnyAssetId, dest: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'rxjs'> {
+    return this.api.tx.genericAsset.transfer(assetId, dest, amount);
+  }
 
-    /**
-     * Mint asset to the destination account
-     * @param assetId The ID or symbol (for reserved asset) of the asset to be minted
-     * @param destination The address of the destination account
-     * @param amount The amount to be minted
-     */
-    mint(assetId: AnyAssetId, destination: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'rxjs'> {
-        return this.api.tx.genericAsset.mint(assetId, destination, amount);
-    }
+  /**
+   * Mint asset to the destination account
+   * @param assetId The ID or symbol (for reserved asset) of the asset to be minted
+   * @param destination The address of the destination account
+   * @param amount The amount to be minted
+   */
+  mint(assetId: AnyAssetId, destination: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'rxjs'> {
+    return this.api.tx.genericAsset.mint(assetId, destination, amount);
+  }
 
-    /**
-     * Burn asset from the source account
-     * @param assetId The ID or symbol (for reserved asset) of the asset to be minted
-     * @param source The address of the source account
-     * @param amount The amount to be burned
-     */
-    burn(assetId: AnyAssetId, source: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'rxjs'> {
-        return this.api.tx.genericAsset.burn(assetId, source, amount);
-    }
+  /**
+   * Burn asset from the source account
+   * @param assetId The ID or symbol (for reserved asset) of the asset to be minted
+   * @param source The address of the source account
+   * @param amount The amount to be burned
+   */
+  burn(assetId: AnyAssetId, source: AnyAddress, amount: AnyNumber): SubmittableExtrinsic<'rxjs'> {
+    return this.api.tx.genericAsset.burn(assetId, source, amount);
+  }
 
-    /**
-     * Query the next available asset ID
-     */
-    get getNextAssetId(): QueryableStorageEntry<'rxjs', AssetId> {
-        return this.api.query.genericAsset.nextAssetId as any;
-    }
+  /**
+   * Query the next available asset ID
+   */
+  get getNextAssetId(): QueryableStorageEntry<'rxjs', AssetId> {
+    return this.api.query.genericAsset.nextAssetId as any;
+  }
 
-    /**
-     * Query the total issuance of an asset
-     * @return a QueryableStorageFunction that needs a argument assetId
-     * @param assetId id or symbol (for reserved asset) of the asset
-     */
-    get getTotalIssuance(): QueryableStorageEntry<'rxjs', Balance> {
-        return this.api.query.genericAsset.totalIssuance as any;
-    }
+  /**
+   * Query the total issuance of an asset
+   * @return a QueryableStorageFunction that needs a argument assetId
+   * @param assetId id or symbol (for reserved asset) of the asset
+   */
+  get getTotalIssuance(): QueryableStorageEntry<'rxjs', Balance> {
+    return this.api.query.genericAsset.totalIssuance as any;
+  }
 
-    // tslint:disable:member-ordering
-    /**
-     * Query free balance of an asset for an account
-     * @param assetId The id or symbol (for reserved asset) of the asset
-     * @param address The address of the account
-     */
-    get getFreeBalance(): QueryableStorageEntry<'rxjs', Balance> {
-        return this.api.query.genericAsset.freeBalance as any;
-    }
+  // tslint:disable:member-ordering
+  /**
+   * Query free balance of an asset for an account
+   * @param assetId The id or symbol (for reserved asset) of the asset
+   * @param address The address of the account
+   */
+  get getFreeBalance(): QueryableStorageEntry<'rxjs', Balance> {
+    return this.api.query.genericAsset.freeBalance as any;
+  }
 
-    /**
-     * Query reserved balance of an asset for an account
-     * @param assetId The id or symbol (for reserved asset) of the asset
-     * @param address The address of the account
-     */
-    get getReservedBalance(): QueryableStorageEntry<'rxjs', Balance> {
-        return this.api.query.genericAsset.reservedBalance as any;
-    }
+  /**
+   * Query reserved balance of an asset for an account
+   * @param assetId The id or symbol (for reserved asset) of the asset
+   * @param address The address of the account
+   */
+  get getReservedBalance(): QueryableStorageEntry<'rxjs', Balance> {
+    return this.api.query.genericAsset.reservedBalance as any;
+  }
 
-    /**
-     * Query total balance of an asset for an account
-     * @param assetId The id or symbol (for reserved asset) of the asset
-     * @param address The address of the account
-     */
-    get getTotalBalance(): QueryableGetBalanceRx {
-        const _fn = this.api.derive.genericAsset.totalBalance as QueryableGetBalanceRx;
-        _fn.at = this.api.derive.genericAsset.totalBalanceAt as any;
+  /**
+   * Query total balance of an asset for an account
+   * @param assetId The id or symbol (for reserved asset) of the asset
+   * @param address The address of the account
+   */
+  get getTotalBalance(): QueryableGetBalanceRx {
+    const _fn = this.api.derive.genericAsset.totalBalance as QueryableGetBalanceRx;
+    _fn.at = this.api.derive.genericAsset.totalBalanceAt as any;
 
-        return _fn;
-    }
+    return _fn;
+  }
 
-    // tslint:enable:member-ordering
+  // tslint:enable:member-ordering
 }

--- a/packages/crml-generic-asset/src/derives/index.ts
+++ b/packages/crml-generic-asset/src/derives/index.ts
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {totalBalance, totalBalanceAt} from './totalBalance';
+export { totalBalance, totalBalanceAt } from './totalBalance';

--- a/packages/crml-generic-asset/src/derives/totalBalance.ts
+++ b/packages/crml-generic-asset/src/derives/totalBalance.ts
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AnyAddress, AnyAssetId} from '@cennznet/types/types';
-import {ApiInterfaceRx} from '@polkadot/api/types';
+import { AnyAddress, AnyAssetId } from '@cennznet/types/types';
+import { ApiInterfaceRx } from '@polkadot/api/types';
 // import {drr} from '@polkadot/api-derive/util/drr';
-import {drr} from '@polkadot/rpc-core/rxjs';
-import {Balance, Hash} from '@polkadot/types/interfaces';
+import { drr } from '@polkadot/rpc-core/rxjs';
+import { Balance, Hash } from '@polkadot/types/interfaces';
 import BN from 'bn.js';
-import {combineLatest, Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
+import { combineLatest, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 export function totalBalance(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId, address: AnyAddress): Observable<BN> => {

--- a/packages/crml-generic-asset/src/index.ts
+++ b/packages/crml-generic-asset/src/index.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {GenericAsset} from './GenericAsset';
-export {GenericAssetRx} from './GenericAssetRx';
-export {AssetType} from './types';
+export { GenericAsset } from './GenericAsset';
+export { GenericAssetRx } from './GenericAssetRx';
+export { AssetType } from './types';
 
-export {default as Plugin} from './plugin';
+export { default as Plugin } from './plugin';

--- a/packages/crml-generic-asset/src/plugin.ts
+++ b/packages/crml-generic-asset/src/plugin.ts
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {IPlugin} from '@cennznet/api/types';
+import { IPlugin } from '@cennznet/api/types';
 // import * as derives from './derives';
-import {GenericAsset} from './GenericAsset';
-import {GenericAssetRx} from './GenericAssetRx';
+import { GenericAsset } from './GenericAsset';
+import { GenericAssetRx } from './GenericAssetRx';
 
 export default ({
   injectName: 'genericAsset',

--- a/packages/crml-generic-asset/src/types.ts
+++ b/packages/crml-generic-asset/src/types.ts
@@ -12,50 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AnyAddress, AnyNumber, CodecArg, IHash} from '@cennznet/types/types';
+import { AnyAddress, AnyNumber, CodecArg, IHash } from '@cennznet/types/types';
 import BN from 'bn.js';
-import {Observable} from 'rxjs';
+import { Observable } from 'rxjs';
 
 export interface CodecArgObject {
-    [index: string]: CodecArg;
+  [index: string]: CodecArg;
 }
 
 export enum AssetType {
-    STAKING = 'staking',
-    SPENDING = 'spending',
-    RESERVE = 'reserve',
-    USER = 'user',
+  STAKING = 'staking',
+  SPENDING = 'spending',
+  RESERVE = 'reserve',
+  USER = 'user',
 }
 
 export interface IAsset {
-    id: number;
-    symbol: string;
-    /**
-     * @deprecated decimals will always be 18, and we expose it in constants.ts
-     */
-    decimals: number;
-    type: AssetType;
+  id: number;
+  symbol: string;
+  /**
+   * @deprecated decimals will always be 18, and we expose it in constants.ts
+   */
+  decimals: number;
+  type: AssetType;
 }
 
 export interface AssetOptionsValue extends CodecArgObject {
-    initialIssuance: AnyNumber;
-    permissions?: {
-        update?: AnyAddress;
-        mint?: AnyAddress;
-        burn?: AnyAddress;
-    };
+  initialIssuance: AnyNumber;
+  permissions?: {
+    update?: AnyAddress;
+    mint?: AnyAddress;
+    burn?: AnyAddress;
+  };
 }
 
 export interface QueryableGetBalance {
-    (assetId: AnyNumber, address: AnyAddress): Promise<BN>;
+  (assetId: AnyNumber, address: AnyAddress): Promise<BN>;
 
-    (assetId: AnyNumber, address: AnyAddress, cb: any): Promise<() => any>;
+  (assetId: AnyNumber, address: AnyAddress, cb: any): Promise<() => any>;
 
-    at(hash: IHash, assetId: AnyNumber, address: AnyAddress): Promise<BN>;
+  at(hash: IHash, assetId: AnyNumber, address: AnyAddress): Promise<BN>;
 }
 
 export interface QueryableGetBalanceRx {
-    (assetId: AnyNumber, address: AnyAddress): Observable<BN>;
+  (assetId: AnyNumber, address: AnyAddress): Observable<BN>;
 
-    at(hash: IHash, assetId: AnyNumber, address: AnyAddress): Observable<BN>;
+  at(hash: IHash, assetId: AnyNumber, address: AnyAddress): Observable<BN>;
 }

--- a/packages/crml-generic-asset/src/utils/utils.ts
+++ b/packages/crml-generic-asset/src/utils/utils.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {isBn, isNumber, isObject, isU8a} from '@cennznet/util';
+import { isBn, isNumber, isObject, isU8a } from '@cennznet/util';
 
 export function isAssetObj(value: any): boolean {
-    return isObject(value) && !isU8a(value) && !isBn(value) && isNumber(value.id);
+  return isObject(value) && !isU8a(value) && !isBn(value) && isNumber(value.id);
 }
 
 export function isStringNumber(str: string): boolean {
-    return !isNaN(Number(str));
+  return !isNaN(Number(str));
 }

--- a/packages/types/src/Doughnut.ts
+++ b/packages/types/src/Doughnut.ts
@@ -14,7 +14,7 @@
 
 import logger from '@cennznet/api/util/logging';
 import Raw from '@polkadot/types/codec/Raw';
-import {AnyU8a, Registry} from '@polkadot/types/types';
+import { AnyU8a, Registry } from '@polkadot/types/types';
 
 /**
  * A v0 Doughnut certificate

--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -4,17 +4,26 @@
 
 // tslint:disable member-ordering no-magic-numbers
 
-import {ExtrinsicPayloadValueV2} from '@cennznet/types/extrinsic/v2/ExtrinsicPayload';
-import {ClassOf, Compact, TypeRegistry} from '@polkadot/types';
+import { ExtrinsicPayloadValueV2 } from '@cennznet/types/extrinsic/v2/ExtrinsicPayload';
+import { ClassOf, Compact, TypeRegistry } from '@polkadot/types';
 import Base from '@polkadot/types/codec/Base';
-import {Address, Balance, Call, EcdsaSignature, Ed25519Signature, Sr25519Signature} from '@polkadot/types/interfaces';
-import {FunctionMetadataLatest} from '@polkadot/types/interfaces/metadata';
-import {AnyU8a, ArgsDef, Codec, IExtrinsic, IExtrinsicEra, IHash, IKeyringPair, Registry} from '@polkadot/types/types';
-import {assert, isHex, isU8a, u8aConcat, u8aToHex, u8aToU8a} from '@polkadot/util';
-import {ChargeTransactionPayment, Index} from '../runtime';
-import {BIT_SIGNED, BIT_UNSIGNED, DEFAULT_VERSION} from './constants';
-import {SignatureOptions} from './types';
-import ExtrinsicV2, {ExtrinsicValueV2} from './v2/Extrinsic';
+import { Address, Balance, Call, EcdsaSignature, Ed25519Signature, Sr25519Signature } from '@polkadot/types/interfaces';
+import { FunctionMetadataLatest } from '@polkadot/types/interfaces/metadata';
+import {
+  AnyU8a,
+  ArgsDef,
+  Codec,
+  IExtrinsic,
+  IExtrinsicEra,
+  IHash,
+  IKeyringPair,
+  Registry,
+} from '@polkadot/types/types';
+import { assert, isHex, isU8a, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
+import { ChargeTransactionPayment, Index } from '../runtime';
+import { BIT_SIGNED, BIT_UNSIGNED, DEFAULT_VERSION } from './constants';
+import { SignatureOptions } from './types';
+import ExtrinsicV2, { ExtrinsicValueV2 } from './v2/Extrinsic';
 
 export type ExtrinsicImpl = ExtrinsicV2;
 export type ExtrinsicValue = ExtrinsicValueV2;
@@ -40,7 +49,7 @@ export default class Extrinsic extends Base<ExtrinsicImpl> implements IExtrinsic
   constructor(
     registry: Registry,
     value: Extrinsic | AnyU8a | Call | ExtrinsicValue | undefined,
-    {version}: ExtrinsicOptions = {}
+    { version }: ExtrinsicOptions = {}
   ) {
     super(registry, Extrinsic.decodeExtrinsic(registry, value, version));
   }
@@ -51,7 +60,7 @@ export default class Extrinsic extends Base<ExtrinsicImpl> implements IExtrinsic
     }
 
     const isSigned = (version & BIT_SIGNED) === BIT_SIGNED;
-    return new ExtrinsicV2(registry, value, {isSigned});
+    return new ExtrinsicV2(registry, value, { isSigned });
   }
 
   static decodeExtrinsic(
@@ -85,7 +94,7 @@ export default class Extrinsic extends Base<ExtrinsicImpl> implements IExtrinsic
 
       return Extrinsic.decodeU8a(registry, value.subarray(offset, total));
     } else if (value instanceof ClassOf(registry, 'Call')) {
-      return Extrinsic.newFromValue(registry, {method: value}, version);
+      return Extrinsic.newFromValue(registry, { method: value }, version);
     }
 
     return Extrinsic.newFromValue(registry, value, version);

--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -4,17 +4,17 @@
 
 // tslint:disable member-ordering no-magic-numbers
 
-import {Compact, Raw, u32} from '@polkadot/types';
+import { Compact, Raw, u32 } from '@polkadot/types';
 import Base from '@polkadot/types/codec/Base';
-import {Balance, Hash} from '@polkadot/types/interfaces/runtime';
-import {IExtrinsicEra, IKeyringPair, Registry} from '@polkadot/types/types';
+import { Balance, Hash } from '@polkadot/types/interfaces/runtime';
+import { IExtrinsicEra, IKeyringPair, Registry } from '@polkadot/types/types';
 
-import {u8aToHex} from '@polkadot/util';
+import { u8aToHex } from '@polkadot/util';
 
-import {ChargeTransactionPayment, Index} from '../runtime';
-import {DEFAULT_VERSION} from './constants';
-import {ExtrinsicPayloadValue} from './types';
-import ExtrinsicPayloadV2, {ExtrinsicPayloadValueV2} from './v2/ExtrinsicPayload';
+import { ChargeTransactionPayment, Index } from '../runtime';
+import { DEFAULT_VERSION } from './constants';
+import { ExtrinsicPayloadValue } from './types';
+import ExtrinsicPayloadV2, { ExtrinsicPayloadValueV2 } from './v2/ExtrinsicPayload';
 
 interface ExtrinsicPayloadOptions {
   version?: number;
@@ -33,7 +33,7 @@ export default class ExtrinsicPayload extends Base<ExtrinsicPayloadVx> {
   constructor(
     registry: Registry,
     value: Partial<ExtrinsicPayloadValue> | Uint8Array | string | undefined,
-    {version}: ExtrinsicPayloadOptions = {}
+    { version }: ExtrinsicPayloadOptions = {}
   ) {
     super(registry, ExtrinsicPayload.decodeExtrinsicPayload(registry, value as ExtrinsicPayloadValue, version));
   }
@@ -116,7 +116,7 @@ export default class ExtrinsicPayload extends Base<ExtrinsicPayloadVx> {
   /**
    * @description Sign the payload with the keypair
    */
-  sign(signerPair: IKeyringPair): {signature: string} {
+  sign(signerPair: IKeyringPair): { signature: string } {
     const signature = this.raw.sign(signerPair);
 
     // This is extensible, so we could quite readily extend to send back extra

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import {Compact, Option, Struct, u8} from '@polkadot/types';
+import { Compact, Option, Struct, u8 } from '@polkadot/types';
 import {
   Address,
   Balance,
@@ -20,10 +20,10 @@ import {
   SignerPayloadJSON as SignerPayloadJSONBase,
   SignerPayloadRaw,
 } from '@polkadot/types/types';
-import {u8aToHex} from '@polkadot/util';
+import { u8aToHex } from '@polkadot/util';
 
 import Doughnut from '../Doughnut';
-import {ChargeTransactionPayment} from '../runtime/transaction-payment';
+import { ChargeTransactionPayment } from '../runtime/transaction-payment';
 import ExtrinsicPayload from './ExtrinsicPayload';
 
 export interface SignerPayloadType extends Struct {
@@ -76,7 +76,7 @@ export default class SignerPayload extends _Payload implements ISignerPayload {
       genesisHash,
       method,
       nonce,
-      runtimeVersion: {specVersion},
+      runtimeVersion: { specVersion },
       tip,
       version,
       doughnut,
@@ -109,7 +109,7 @@ export default class SignerPayload extends _Payload implements ISignerPayload {
     const payload = this.toPayload();
     // NOTE Explicitly pass the bare flag so the method is encoded un-prefixed (non-decodable, for signing only)
     const data = u8aToHex(
-      new ExtrinsicPayload(this.registry, payload, {version: payload.version}).toU8a({method: true})
+      new ExtrinsicPayload(this.registry, payload, { version: payload.version }).toU8a({ method: true })
     );
 
     return {

--- a/packages/types/src/extrinsic/index.ts
+++ b/packages/types/src/extrinsic/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {default as Extrinsic} from './Extrinsic';
-export {default as ExtrinsicPayload} from './ExtrinsicPayload';
-export {default as SignerPayload} from './SignerPayload';
-export {default as ExtrinsicSignatureV4} from './v2/ExtrinsicSignature';
+export { default as Extrinsic } from './Extrinsic';
+export { default as ExtrinsicPayload } from './ExtrinsicPayload';
+export { default as SignerPayload } from './SignerPayload';
+export { default as ExtrinsicSignatureV4 } from './v2/ExtrinsicSignature';

--- a/packages/types/src/extrinsic/types.ts
+++ b/packages/types/src/extrinsic/types.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Enum} from '@polkadot/types';
-import {Option, Vec} from '@polkadot/types/codec';
-import {InterfaceRegistry} from '@polkadot/types/interfaceRegistry';
+import { Enum } from '@polkadot/types';
+import { Option, Vec } from '@polkadot/types/codec';
+import { InterfaceRegistry } from '@polkadot/types/interfaceRegistry';
 import {
   AnyNumber,
   AnyU8a,
@@ -25,10 +25,10 @@ import {
   RuntimeVersionInterface,
   SignatureOptions as SignatureOptionsBase,
 } from '@polkadot/types/types';
-import {AccountId} from '@cennznet/types/interfaces';
+import { AccountId } from '@cennznet/types/interfaces';
 import Doughnut from '../Doughnut';
-import {AssetId, AssetInfo} from '../runtime/ga';
-import {ChargeTransactionPayment, FeeExchange} from '../runtime/transaction-payment';
+import { AssetId, AssetInfo } from '../runtime/ga';
+import { ChargeTransactionPayment, FeeExchange } from '../runtime/transaction-payment';
 
 export interface ExtrinsicOptions {
   isSigned?: boolean;

--- a/packages/types/src/extrinsic/v2/Extrinsic.ts
+++ b/packages/types/src/extrinsic/v2/Extrinsic.ts
@@ -14,13 +14,13 @@
 
 // tslint:disable member-ordering no-magic-numbers
 
-import {ClassOf, createType, Struct, TypeRegistry} from '@polkadot/types';
-import {Address, Call} from '@polkadot/types/interfaces/runtime';
-import {IExtrinsicImpl, IKeyringPair, Registry, SignatureOptions} from '@polkadot/types/types';
-import {isU8a, u8aConcat} from '@polkadot/util';
+import { ClassOf, createType, Struct, TypeRegistry } from '@polkadot/types';
+import { Address, Call } from '@polkadot/types/interfaces/runtime';
+import { IExtrinsicImpl, IKeyringPair, Registry, SignatureOptions } from '@polkadot/types/types';
+import { isU8a, u8aConcat } from '@polkadot/util';
 
-import {ExtrinsicOptions} from '../types';
-import {ExtrinsicPayloadValueV2} from './ExtrinsicPayload';
+import { ExtrinsicOptions } from '../types';
+import { ExtrinsicPayloadValueV2 } from './ExtrinsicPayload';
 import ExtrinsicSignatureV2 from './ExtrinsicSignature';
 
 export interface ExtrinsicValueV2 {
@@ -39,7 +39,7 @@ export default class ExtrinsicV2 extends Struct implements IExtrinsicImpl {
   constructor(
     registry: Registry,
     value?: Uint8Array | ExtrinsicValueV2 | Call,
-    {isSigned}: Partial<ExtrinsicOptions> = {}
+    { isSigned }: Partial<ExtrinsicOptions> = {}
   ) {
     super(
       registry,
@@ -54,17 +54,17 @@ export default class ExtrinsicV2 extends Struct implements IExtrinsicImpl {
   static decodeExtrinsic(
     registry: Registry,
     value?: Call | Uint8Array | ExtrinsicValueV2,
-    isSigned: boolean = false
+    isSigned = false
   ): ExtrinsicValueV2 {
     if (!value) {
       return {};
     } else if (value instanceof ExtrinsicV2) {
       return value;
     } else if (value instanceof ClassOf(registry, 'Call')) {
-      return {method: value as Call};
+      return { method: value as Call };
     } else if (isU8a(value)) {
       // here we decode manually since we need to pull through the version information
-      const signature = new ExtrinsicSignatureV2(registry, value, {isSigned});
+      const signature = new ExtrinsicSignatureV2(registry, value, { isSigned });
       const method = createType(registry, 'Call', value.subarray(signature.encodedLength));
 
       return {

--- a/packages/types/src/extrinsic/v2/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v2/ExtrinsicPayload.ts
@@ -13,16 +13,16 @@
 // limitations under the License.
 
 // tslint:disable member-ordering no-magic-numbers
-import {Bytes, Compact, Struct, u32, u64} from '@polkadot/types';
-import {Balance, ExtrinsicEra, Hash} from '@polkadot/types/interfaces/runtime';
-import {sign} from '@polkadot/types/primitive/Extrinsic/util';
-import {AnyNumber, AnyU8a, IExtrinsicEra, IKeyringPair, IMethod, Registry} from '@polkadot/types/types';
-import {u8aConcat} from '@polkadot/util';
+import { Bytes, Compact, Struct, u32, u64 } from '@polkadot/types';
+import { Balance, ExtrinsicEra, Hash } from '@polkadot/types/interfaces/runtime';
+import { sign } from '@polkadot/types/primitive/Extrinsic/util';
+import { AnyNumber, AnyU8a, IExtrinsicEra, IKeyringPair, IMethod, Registry } from '@polkadot/types/types';
+import { u8aConcat } from '@polkadot/util';
 
 import Option from '@polkadot/types/codec/Option';
 import Doughnut from '../../Doughnut';
-import {ChargeTransactionPayment, Index} from '../../runtime';
-import {CennznetInterfaceTypes} from '../types';
+import { ChargeTransactionPayment, Index } from '../../runtime';
+import { CennznetInterfaceTypes } from '../types';
 
 export interface ExtrinsicPayloadValueV2 {
   blockHash: AnyU8a;
@@ -146,6 +146,6 @@ export default class ExtrinsicPayloadV2 extends Struct {
    * @description Sign the payload with the keypair
    */
   sign(signerPair: IKeyringPair): Uint8Array {
-    return sign(signerPair, this.toU8a({method: true}), {withType: true});
+    return sign(signerPair, this.toU8a({ method: true }), { withType: true });
   }
 }

--- a/packages/types/src/extrinsic/v2/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v2/ExtrinsicSignature.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // tslint:disable member-ordering no-magic-numbers
-import {Compact, createType, Struct, TypeRegistry} from '@polkadot/types';
+import { Compact, createType, Struct, TypeRegistry } from '@polkadot/types';
 import Option from '@polkadot/types/codec/Option';
 import {
   Address,
@@ -25,14 +25,14 @@ import {
   MultiSignature,
   Sr25519Signature,
 } from '@polkadot/types/interfaces/runtime';
-import {ExtrinsicSignatureOptions} from '@polkadot/types/primitive/Extrinsic/types';
-import {IExtrinsicSignature, IKeyringPair, Registry} from '@polkadot/types/types';
-import {u8aConcat} from '@polkadot/util';
+import { ExtrinsicSignatureOptions } from '@polkadot/types/primitive/Extrinsic/types';
+import { IExtrinsicSignature, IKeyringPair, Registry } from '@polkadot/types/types';
+import { u8aConcat } from '@polkadot/util';
 import Doughnut from '../../Doughnut';
-import {ChargeTransactionPayment, Index} from '../../runtime';
-import {EMPTY_U8A, IMMORTAL_ERA} from '../constants';
-import {ExtrinsicV2SignatureOptions} from '../types';
-import ExtrinsicPayloadV2, {ExtrinsicPayloadValueV2} from './ExtrinsicPayload';
+import { ChargeTransactionPayment, Index } from '../../runtime';
+import { EMPTY_U8A, IMMORTAL_ERA } from '../constants';
+import { ExtrinsicV2SignatureOptions } from '../types';
+import ExtrinsicPayloadV2, { ExtrinsicPayloadValueV2 } from './ExtrinsicPayload';
 
 /**
  * @name ExtrinsicSignature
@@ -43,7 +43,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
   constructor(
     registry: Registry,
     value: ExtrinsicSignatureV2 | Uint8Array | undefined,
-    {isSigned}: ExtrinsicSignatureOptions = {}
+    { isSigned }: ExtrinsicSignatureOptions = {}
   ) {
     super(
       registry,
@@ -61,7 +61,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
 
   static decodeExtrinsicSignature(
     value: ExtrinsicSignatureV2 | Uint8Array | undefined,
-    isSigned: boolean = false
+    isSigned = false
   ): ExtrinsicSignatureV2 | Uint8Array {
     if (!value) {
       return EMPTY_U8A;
@@ -144,7 +144,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
   private injectSignature(
     signer: Address,
     signature: MultiSignature,
-    {doughnut, era, nonce, tip, transactionPayment}: ExtrinsicPayloadV2
+    { doughnut, era, nonce, tip, transactionPayment }: ExtrinsicPayloadV2
   ): IExtrinsicSignature {
     this.set('doughnut', doughnut);
     this.set('era', era);
@@ -182,7 +182,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
       genesisHash,
       nonce,
       doughnut,
-      runtimeVersion: {specVersion},
+      runtimeVersion: { specVersion },
       tip,
       transactionPayment,
     }: ExtrinsicV2SignatureOptions
@@ -214,7 +214,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
       genesisHash,
       nonce,
       doughnut,
-      runtimeVersion: {specVersion},
+      runtimeVersion: { specVersion },
       tip,
       transactionPayment,
     }: ExtrinsicV2SignatureOptions
@@ -226,7 +226,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
       genesisHash,
       nonce,
       doughnut,
-      runtimeVersion: {specVersion},
+      runtimeVersion: { specVersion },
       tip,
       transactionPayment,
     } as ExtrinsicV2SignatureOptions);
@@ -247,7 +247,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
       nonce,
       doughnut,
       feeExchange,
-      runtimeVersion: {specVersion},
+      runtimeVersion: { specVersion },
       tip,
       transactionPayment,
     }: ExtrinsicV2SignatureOptions
@@ -259,7 +259,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
       genesisHash,
       nonce,
       doughnut,
-      runtimeVersion: {specVersion},
+      runtimeVersion: { specVersion },
       tip,
       transactionPayment,
     } as ExtrinsicV2SignatureOptions);

--- a/packages/types/src/runtime/attestation/Topic.ts
+++ b/packages/types/src/runtime/attestation/Topic.ts
@@ -15,9 +15,9 @@
 /*
     Custom `Topic` type for Attestation module.
  */
-import {ClassOf, TypeRegistry} from '@polkadot/types';
-import {Registry} from '@polkadot/types/types';
-import {isHex, isString, stringToU8a, u8aToString} from '@polkadot/util';
+import { ClassOf, TypeRegistry } from '@polkadot/types';
+import { Registry } from '@polkadot/types/types';
+import { isHex, isString, stringToU8a, u8aToString } from '@polkadot/util';
 
 function isAscii(str: string) {
   return /^[\x20-\x7E]*$/.test(str);

--- a/packages/types/src/runtime/attestation/Value.ts
+++ b/packages/types/src/runtime/attestation/Value.ts
@@ -15,7 +15,7 @@
 /*
     Custom `Value` type for Attestation module.
  */
-import {ClassOf, TypeRegistry} from '@polkadot/types';
+import { ClassOf, TypeRegistry } from '@polkadot/types';
 const registry = new TypeRegistry();
 
 export default class AttestationValue extends ClassOf(registry, 'H256') {}

--- a/packages/types/src/runtime/attestation/index.ts
+++ b/packages/types/src/runtime/attestation/index.ts
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {default as AttestationTopic} from './Topic';
-export {default as AttestationValue} from './Value';
+export { default as AttestationTopic } from './Topic';
+export { default as AttestationValue } from './Value';

--- a/packages/types/src/runtime/cennzx/ExchangeKey.ts
+++ b/packages/types/src/runtime/cennzx/ExchangeKey.ts
@@ -1,5 +1,5 @@
-import {Tuple} from '@polkadot/types';
+import { Tuple } from '@polkadot/types';
 
-import {AssetId} from '../ga';
+import { AssetId } from '../ga';
 
 export default class ExchangeKey extends Tuple.with([AssetId, AssetId]) {}

--- a/packages/types/src/runtime/cennzx/FeeRate.ts
+++ b/packages/types/src/runtime/cennzx/FeeRate.ts
@@ -1,4 +1,4 @@
-import {ClassOf, TypeRegistry} from '@polkadot/types';
+import { ClassOf, TypeRegistry } from '@polkadot/types';
 
 const registry = new TypeRegistry();
 export default class FeeRate extends ClassOf(registry, 'u128') {

--- a/packages/types/src/runtime/cennzx/index.ts
+++ b/packages/types/src/runtime/cennzx/index.ts
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {default as ExchangeKey} from './ExchangeKey';
-export {default as FeeRate} from './FeeRate';
+export { default as ExchangeKey } from './ExchangeKey';
+export { default as FeeRate } from './FeeRate';

--- a/packages/types/src/runtime/cennzx/types.ts
+++ b/packages/types/src/runtime/cennzx/types.ts
@@ -1,4 +1,4 @@
-import {Codec} from '@polkadot/types/types';
+import { Codec } from '@polkadot/types/types';
 
 import AssetId from '../ga/AssetId';
 

--- a/packages/types/src/runtime/ga/AssetId.ts
+++ b/packages/types/src/runtime/ga/AssetId.ts
@@ -17,6 +17,6 @@
  @plugnet/types
 */
 
-import {u32} from '@polkadot/types';
+import { u32 } from '@polkadot/types';
 
 export default u32;

--- a/packages/types/src/runtime/ga/AssetInfo.ts
+++ b/packages/types/src/runtime/ga/AssetInfo.ts
@@ -16,12 +16,12 @@
  Custom `AssetInfo` type for generic asset module.
 */
 
-import {Struct, u8, Vec} from '@polkadot/types';
-import {Registry} from '@polkadot/types/types';
+import { Struct, u8, Vec } from '@polkadot/types';
+import { Registry } from '@polkadot/types/types';
 
 export default class AssetInfo extends Struct {
   constructor(registry: Registry, value: any) {
-    super(registry, {symbol: 'Vec<u8>', decimalPlaces: u8}, value);
+    super(registry, { symbol: 'Vec<u8>', decimalPlaces: u8 }, value);
   }
 
   get symbol(): Vec<u8> {

--- a/packages/types/src/runtime/ga/AssetOptions.ts
+++ b/packages/types/src/runtime/ga/AssetOptions.ts
@@ -16,14 +16,14 @@
  Custom `AssetOptions` type for generic asset module.
 */
 
-import {Struct} from '@polkadot/types';
-import {Balance} from '@polkadot/types/interfaces';
-import {Registry} from '@polkadot/types/types';
+import { Struct } from '@polkadot/types';
+import { Balance } from '@polkadot/types/interfaces';
+import { Registry } from '@polkadot/types/types';
 import PermissionLatest from './PermissionsV1';
 
 export default class AssetOptions extends Struct {
   constructor(registry: Registry, value: any) {
-    super(registry, {initialIssuance: 'Compact<Balance>', permissions: PermissionLatest}, value);
+    super(registry, { initialIssuance: 'Compact<Balance>', permissions: PermissionLatest }, value);
   }
 
   get initialIssuance(): Balance {

--- a/packages/types/src/runtime/ga/BalanceLock.ts
+++ b/packages/types/src/runtime/ga/BalanceLock.ts
@@ -1,8 +1,8 @@
-import {Struct} from '@polkadot/types';
-import {Balance, LockIdentifier} from '@polkadot/types/interfaces';
-import {Registry} from '@polkadot/types/types';
+import { Struct } from '@polkadot/types';
+import { Balance, LockIdentifier } from '@polkadot/types/interfaces';
+import { Registry } from '@polkadot/types/types';
 
-import {WithdrawReasons} from './';
+import { WithdrawReasons } from './';
 
 // It describes a lock on a GA account balance for some amount and reasons.
 export default class BalanceLock extends Struct {

--- a/packages/types/src/runtime/ga/Owner.ts
+++ b/packages/types/src/runtime/ga/Owner.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ClassOf, TypeRegistry} from '@polkadot/types';
+import { ClassOf, TypeRegistry } from '@polkadot/types';
 
 const registry = new TypeRegistry();
 export default class Owner extends ClassOf(registry, 'Option<AccountId>') {}

--- a/packages/types/src/runtime/ga/PermissionVersions.ts
+++ b/packages/types/src/runtime/ga/PermissionVersions.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Enum} from '@polkadot/types';
+import { Enum } from '@polkadot/types';
 import PermissionsV1 from './PermissionsV1';
 
-export default class PermissionVersions extends Enum.with({PermissionsV1}) {}
+export default class PermissionVersions extends Enum.with({ PermissionsV1 }) {}

--- a/packages/types/src/runtime/ga/PermissionsV1.ts
+++ b/packages/types/src/runtime/ga/PermissionsV1.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Struct} from '@polkadot/types';
-import {Registry} from '@polkadot/types/types';
+import { Struct } from '@polkadot/types';
+import { Registry } from '@polkadot/types/types';
 import Owner from './Owner';
 
 /**
@@ -21,7 +21,7 @@ import Owner from './Owner';
  */
 export default class PermissionsV1 extends Struct {
   constructor(registry: Registry, value: any) {
-    super(registry, {update: Owner, mint: Owner, burn: Owner}, value);
+    super(registry, { update: Owner, mint: Owner, burn: Owner }, value);
   }
 
   get update(): Owner {

--- a/packages/types/src/runtime/ga/WithdrawReasons.ts
+++ b/packages/types/src/runtime/ga/WithdrawReasons.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {i8} from '@polkadot/types';
+import { i8 } from '@polkadot/types';
 
 // See: https://github.com/plugblockchain/plug-blockchain/blob/f580bbbb496f66655b27105e27e9d1e1d52bbb02/frame/support/src/traits.rs#L737-L756
 const ReasonMask = {

--- a/packages/types/src/runtime/ga/index.ts
+++ b/packages/types/src/runtime/ga/index.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {default as AssetId} from './AssetId';
-export {default as AssetOptions} from './AssetOptions';
-export {default as Owner} from './Owner';
-export {default as PermissionsV1, default as PermissionLatest} from './PermissionsV1';
-export {default as PermissionVersions} from './PermissionVersions';
-export {default as AssetInfo} from './AssetInfo';
-export {default as WithdrawReasons} from './WithdrawReasons';
-export {default as BalanceLock} from './BalanceLock';
+export { default as AssetId } from './AssetId';
+export { default as AssetOptions } from './AssetOptions';
+export { default as Owner } from './Owner';
+export { default as PermissionsV1, default as PermissionLatest } from './PermissionsV1';
+export { default as PermissionVersions } from './PermissionVersions';
+export { default as AssetInfo } from './AssetInfo';
+export { default as WithdrawReasons } from './WithdrawReasons';
+export { default as BalanceLock } from './BalanceLock';

--- a/packages/types/src/runtime/index.ts
+++ b/packages/types/src/runtime/index.ts
@@ -20,4 +20,4 @@ export * from './sylo';
 export * from './transaction-payment';
 
 // The CENNZnet nonce type
-export {u64 as Index} from '@polkadot/types';
+export { u64 as Index } from '@polkadot/types';

--- a/packages/types/src/runtime/staking/index.ts
+++ b/packages/types/src/runtime/staking/index.ts
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Enum} from '@polkadot/types';
-import {Registry} from '@polkadot/types/types';
-import {AccountId} from '@cennznet/types/interfaces';
+import { Enum } from '@polkadot/types';
+import { Registry } from '@polkadot/types/types';
+import { AccountId } from '@cennznet/types/interfaces';
 
 // Specifies which account staking rewards should be paid too.
 // Note: Polkadot has an additional 'Staked' option which is not supported in CENNZnet
 // due to the fact that the reward currency is different from the staked currency.
 export class RewardDestination extends Enum {
   constructor(registry: Registry, value: any) {
-    super(registry, {Stash: 'Null', Controller: 'Null', Account: 'AccountId'}, value);
+    super(registry, { Stash: 'Null', Controller: 'Null', Account: 'AccountId' }, value);
   }
 
   get isStash(): boolean {

--- a/packages/types/src/runtime/sylo/index.ts
+++ b/packages/types/src/runtime/sylo/index.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ClassOf, Enum, Null, Struct, Text, Tuple, TypeRegistry, Vec} from '@polkadot/types';
-import {Registry} from '@polkadot/types/types';
-import {u8aToHex} from '@polkadot/util';
+import { ClassOf, Enum, Null, Struct, Text, Tuple, TypeRegistry, Vec } from '@polkadot/types';
+import { Registry } from '@polkadot/types/types';
+import { u8aToHex } from '@polkadot/util';
 
 const GROUP_JSON_MAP = new Map([['groupId', 'group_id']]);
 
@@ -38,7 +38,7 @@ const MEMBER_JSON_MAP = new Map([['userId', 'user_id']]);
 
 export class Member extends Struct {
   constructor(registry: Registry, value) {
-    super(registry, {userId: 'AccountId', roles: Vec.with(MemberRoles), meta: Meta}, value, MEMBER_JSON_MAP);
+    super(registry, { userId: 'AccountId', roles: Vec.with(MemberRoles), meta: Meta }, value, MEMBER_JSON_MAP);
   }
 
   toJSON() {
@@ -81,7 +81,7 @@ const PENDING_INVITE_JSON_MAP = new Map([['inviteKey', 'invite_key']]);
 
 export class PendingInvite extends Struct {
   constructor(registry: Registry, value) {
-    super(registry, {inviteKey: 'H256', meta: Meta, roles: Vec.with(MemberRoles)}, value, PENDING_INVITE_JSON_MAP);
+    super(registry, { inviteKey: 'H256', meta: Meta, roles: Vec.with(MemberRoles) }, value, PENDING_INVITE_JSON_MAP);
   }
 
   toJSON() {
@@ -95,7 +95,7 @@ export class PendingInvite extends Struct {
 
 export class AcceptPayload extends Struct {
   constructor(registry: Registry, value) {
-    super(registry, {account_id: 'AccountId'}, value);
+    super(registry, { account_id: 'AccountId' }, value);
   }
 }
 const registry = new TypeRegistry();
@@ -109,7 +109,7 @@ class WithdrawnPreKeyBundle extends Tuple.with(['AccountId', 'u32', 'Bytes']) {}
 
 class PreKeyBundlesResponse extends Vec.with(WithdrawnPreKeyBundle) {}
 
-export class Response extends Enum.with({DeviceIdResponse, PreKeyBundlesResponse, Null}) {}
+export class Response extends Enum.with({ DeviceIdResponse, PreKeyBundlesResponse, Null }) {}
 
 export class VaultKey extends ClassOf(registry, 'Bytes') {}
 

--- a/packages/types/src/runtime/transaction-payment/TransactionPayment.ts
+++ b/packages/types/src/runtime/transaction-payment/TransactionPayment.ts
@@ -1,4 +1,4 @@
-export function generateTransactionPayment({tip, assetId, maxPayment}) {
+export function generateTransactionPayment({ tip, assetId, maxPayment }) {
   const feeExchange = {
     assetId: assetId,
     maxPayment: maxPayment,

--- a/packages/types/src/runtime/transaction-payment/index.ts
+++ b/packages/types/src/runtime/transaction-payment/index.ts
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Enum, Struct} from '@polkadot/types';
+import { Enum, Struct } from '@polkadot/types';
 import Compact from '@polkadot/types/codec/Compact';
 import Option from '@polkadot/types/codec/Option';
-import {AssetId, Balance} from '@polkadot/types/interfaces/runtime';
-import {Registry} from '@polkadot/types/types';
+import { AssetId, Balance } from '@polkadot/types/interfaces/runtime';
+import { Registry } from '@polkadot/types/types';
 
 /* [[FeeExchangeV1]] when included in a transaction it indicates network fees should be
  * paid in `assetId` by paying up to `maxPayment` after the exchange rate is calculated.
  */
 export class FeeExchangeV1 extends Struct {
   constructor(registry: Registry, value?: any) {
-    super(registry, {assetId: 'Compact<AssetId>', maxPayment: 'Compact<Balance>'}, value);
+    super(registry, { assetId: 'Compact<AssetId>', maxPayment: 'Compact<Balance>' }, value);
   }
   get assetId(): AssetId {
     return this.get('assetId') as AssetId;
@@ -39,7 +39,7 @@ export class FeeExchangeV1 extends Struct {
 
 export class FeeExchange extends Enum {
   constructor(registry: Registry, value: any) {
-    super(registry, {FeeExchangeV1}, value);
+    super(registry, { FeeExchangeV1 }, value);
   }
 }
 
@@ -49,7 +49,7 @@ export class FeeExchange extends Enum {
  */
 export class ChargeTransactionPayment extends Struct {
   constructor(registry: Registry, value: any) {
-    super(registry, {tip: 'Compact<Balance>', feeExchange: 'Option<FeeExchange>'}, value);
+    super(registry, { tip: 'Compact<Balance>', feeExchange: 'Option<FeeExchange>' }, value);
   }
 
   get tip(): Compact<Balance> {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -1,5 +1,5 @@
-import {AccountId, Address} from '@polkadot/types/interfaces';
-import {AnyNumber} from '@polkadot/types/types';
+import { AccountId, Address } from '@polkadot/types/interfaces';
+import { AnyNumber } from '@polkadot/types/types';
 import BN from 'bn.js';
 export * from '@polkadot/types/types';
 

--- a/packages/util/src/format/stripEndZero.ts
+++ b/packages/util/src/format/stripEndZero.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assert, isUndefined} from '@polkadot/util';
+import { assert, isUndefined } from '@polkadot/util';
 
 const STRIP_ZERO = /^(.*?)(0*)$/;
 
@@ -21,6 +21,6 @@ const STRIP_ZERO = /^(.*?)(0*)$/;
  * @param value
  */
 export function stripEndZero(value: string) {
-    assert(!isUndefined(value), 'must not be undefined');
-    return STRIP_ZERO.exec(value)[1];
+  assert(!isUndefined(value), 'must not be undefined');
+  return STRIP_ZERO.exec(value)[1];
 }

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -15,7 +15,7 @@
 export * from '@polkadot/util';
 export * from '@polkadot/util-crypto';
 
-export {default as stripEndZero} from './format/stripEndZero';
-export {default as isSafeInteger} from './is/integer';
-export {default as toFixed} from './number/toFixed';
+export { default as stripEndZero } from './format/stripEndZero';
+export { default as isSafeInteger } from './is/integer';
+export { default as toFixed } from './number/toFixed';
 export * from './unit';

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {KeyringPair, KeyringPair$Json, KeyringPair$Meta} from '@polkadot/keyring/types';
+export { KeyringPair, KeyringPair$Json, KeyringPair$Meta } from '@polkadot/keyring/types';

--- a/packages/util/src/unit/formatUnits.ts
+++ b/packages/util/src/unit/formatUnits.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assert} from '@polkadot/util';
+import { assert } from '@polkadot/util';
 import BN from 'bn.js';
-import {stripEndZero} from '../format/stripEndZero';
+import { stripEndZero } from '../format/stripEndZero';
 import isSafeInteger from '../is/integer';
 
 /**
@@ -23,16 +23,16 @@ import isSafeInteger from '../is/integer';
  * @param decimals
  */
 export default function formatUnits(unValue: BN | number | string, decimals: number): string {
-    assert(isSafeInteger(unValue), 'not a safe integer');
-    let un = new BN(unValue).toString();
-    un = un.padStart(decimals + 1, '0');
-    const splitPos = un.length - decimals;
-    const intPart = un.slice(0, splitPos);
-    let fractionPart = un.slice(splitPos);
-    fractionPart = stripEndZero(fractionPart);
-    if (fractionPart !== '') {
-        return `${intPart}.${fractionPart}`;
-    } else {
-        return intPart;
-    }
+  assert(isSafeInteger(unValue), 'not a safe integer');
+  let un = new BN(unValue).toString();
+  un = un.padStart(decimals + 1, '0');
+  const splitPos = un.length - decimals;
+  const intPart = un.slice(0, splitPos);
+  let fractionPart = un.slice(splitPos);
+  fractionPart = stripEndZero(fractionPart);
+  if (fractionPart !== '') {
+    return `${intPart}.${fractionPart}`;
+  } else {
+    return intPart;
+  }
 }

--- a/packages/util/src/unit/index.ts
+++ b/packages/util/src/unit/index.ts
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export {default as formatUnits} from './formatUnits';
-export {default as parseUnits} from './parseUnits';
+export { default as formatUnits } from './formatUnits';
+export { default as parseUnits } from './parseUnits';

--- a/packages/util/src/unit/parseUnits.ts
+++ b/packages/util/src/unit/parseUnits.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assert, isNumber} from '@polkadot/util';
+import { assert, isNumber } from '@polkadot/util';
 import BN from 'bn.js';
-import {stripEndZero} from '../format/stripEndZero';
+import { stripEndZero } from '../format/stripEndZero';
 import isSafeInteger from '../is/integer';
-import {toFixed} from '../number/toFixed';
+import { toFixed } from '../number/toFixed';
 
 /**
  * format a amount from unit `un` to decimals passed in.


### PR DESCRIPTION
Updated prettierrc to use bracketSpacing as true to support a space after curly brace. 

Changed prettierrc's "bracketSpacing" field to true. Prettier formatted the project to use the space between {} curly braces.