### PR TITLE
Chore/consistency

### DIFF
--- a/packages/api/src/Api.ts
+++ b/packages/api/src/Api.ts
@@ -42,9 +42,6 @@ export class Api extends ApiPromise {
         };
 
         api.isReady.then(res => {
-          // alias cennzxSpot as cennzx
-          api.query.cennzx = api.query.cennzxSpot;
-          api.tx.cennzx = api.tx.cennzxSpot;
           //  Remove error listener if API initialization success.
           (api as any)._eventemitter.removeListener('error', rejectError);
           resolve((res as unknown) as Api);

--- a/packages/api/src/Api.ts
+++ b/packages/api/src/Api.ts
@@ -42,6 +42,9 @@ export class Api extends ApiPromise {
         };
 
         api.isReady.then(res => {
+          // alias cennzxSpot as cennzx
+          api.query.cennzx = api.query.cennzxSpot;
+          api.tx.cennzx = api.tx.cennzxSpot;
           //  Remove error listener if API initialization success.
           (api as any)._eventemitter.removeListener('error', rejectError);
           resolve((res as unknown) as Api);

--- a/packages/api/src/derives/fees/estimateFee.ts
+++ b/packages/api/src/derives/fees/estimateFee.ts
@@ -14,12 +14,12 @@ import { catchError, first, map, switchMap } from 'rxjs/operators';
 // The estimate can be in any currency(userFeeAssetId) provided there is enough liquidity in the exchange pool for that currency.
 // In case user wants to know estimated fee in different currency, the interface also needs the maxPayment that can used from currency as fee.
 // Scenarios when this function can be useful
-// 1. User wants to show its Dapp user's, price the extrinsic will cost in default currency
+// 1. DAPP creator wants to show price the extrinsic will cost in default currency
 //   const extrinsic = api.tx.genericAsset
 //             .transfer(assetId, address, amount);
 //   const userFeeAssetId = '16001' // default spending asset
 //   const feeFromQuery = await api.derive.fees.estimateFee({extrinsic, userFeeAssetId})
-// 2. Dapp user's desire to pay fee in different asset(not the default fee asset)
+// 2. DAPP user desire to pay fee in different asset(not the default fee asset)
 //    const extrinsic = api.tx.genericAsset
 //              .transfer(assetId, address, amount);
 //    const userFeeAssetId = '16005' // asset to pay fee in

--- a/packages/api/src/derives/fees/estimateFee.ts
+++ b/packages/api/src/derives/fees/estimateFee.ts
@@ -1,7 +1,6 @@
 import { ApiInterfaceRx } from '@cennznet/api/types';
 import Extrinsic from '@cennznet/types/extrinsic/Extrinsic';
 import { generateTransactionPayment } from '@cennznet/types/runtime/transaction-payment/TransactionPayment';
-import { AnyAssetId, IExtrinsic } from '@cennznet/types/types';
 import { drr } from '@polkadot/rpc-core/rxjs';
 import { TypeRegistry } from '@cennznet/types';
 import { RuntimeDispatchInfo } from '@cennznet/types/interfaces';

--- a/packages/api/src/derives/index.ts
+++ b/packages/api/src/derives/index.ts
@@ -14,7 +14,7 @@
 
 import { ApiTypes } from '@cennznet/api/types';
 import * as attestation from '@cennznet/crml-attestation/derives';
-import * as cennzx from '@cennznet/crml-cennzx-spot/derives';
+import * as cennzxSpot from '@cennznet/crml-cennzx-spot/derives';
 import * as genericAsset from '@cennznet/crml-generic-asset/derives';
 import { AnyFunction } from '@cennznet/types/types';
 import { ApiInterfaceRx, MethodResult } from '@polkadot/api/types';
@@ -25,7 +25,7 @@ import * as staking from './staking';
 
 export type DeriveFunc = (api: ApiInterfaceRx) => (...args: any[]) => Observable<any>;
 
-export const derive = { attestation, cennzx, fees, staking, session, genericAsset };
+export const derive = { attestation, cennzxSpot, fees, staking, session, genericAsset };
 
 export type DecoratedCennznetDerive<
   ApiType extends ApiTypes,

--- a/packages/api/src/derives/index.ts
+++ b/packages/api/src/derives/index.ts
@@ -14,7 +14,7 @@
 
 import { ApiTypes } from '@cennznet/api/types';
 import * as attestation from '@cennznet/crml-attestation/derives';
-import * as cennzxSpot from '@cennznet/crml-cennzx-spot/derives';
+import * as cennzx from '@cennznet/crml-cennzx-spot/derives';
 import * as genericAsset from '@cennznet/crml-generic-asset/derives';
 import { AnyFunction } from '@cennznet/types/types';
 import { ApiInterfaceRx, MethodResult } from '@polkadot/api/types';
@@ -25,7 +25,7 @@ import * as staking from './staking';
 
 export type DeriveFunc = (api: ApiInterfaceRx) => (...args: any[]) => Observable<any>;
 
-export const derive = { attestation, cennzxSpot, fees, staking, session, genericAsset };
+export const derive = { attestation, cennzx, fees, staking, session, genericAsset };
 
 export type DecoratedCennznetDerive<
   ApiType extends ApiTypes,

--- a/packages/api/src/derives/staking/stakingAccount.ts
+++ b/packages/api/src/derives/staking/stakingAccount.ts
@@ -6,7 +6,6 @@ import { memo } from '@polkadot/api-derive/util';
 import { createType, Option, RewardDestination } from '@cennznet/types';
 import {
   AccountId,
-  EraIndex,
   Exposure,
   Keys,
   Nominations,

--- a/packages/api/src/rpc/cennzx.ts
+++ b/packages/api/src/rpc/cennzx.ts
@@ -4,7 +4,7 @@ import createMethod from '@polkadot/jsonrpc/create/method';
 import createParam from '@polkadot/jsonrpc/create/param';
 
 const buyPrice: RpcMethodOpt = {
-  description: 'Retrieves the spot exchange buy price',
+  description: 'Retrieves the CENNZX exchange buy price',
   isOptional: true,
   params: [
     createParam('AssetToBuy', 'AssetId'),
@@ -15,7 +15,7 @@ const buyPrice: RpcMethodOpt = {
 };
 
 const sellPrice: RpcMethodOpt = {
-  description: 'Retrieves the spot exchange sell price',
+  description: 'Retrieves the CENNZX exchange sell price',
   isOptional: true,
   params: [
     createParam('AssetToSell', 'AssetId'),

--- a/packages/api/src/rpc/cennzx.ts
+++ b/packages/api/src/rpc/cennzx.ts
@@ -25,6 +25,7 @@ const sellPrice: RpcMethodOpt = {
   type: 'Balance',
 };
 
+// Returns the core asset price and investment asset's price for investment asset Id
 const liquidityPrice: RpcMethodOpt = {
   description: 'Get the price of liquidity for the given asset ID',
   isOptional: true,
@@ -32,6 +33,7 @@ const liquidityPrice: RpcMethodOpt = {
   type: '(Balance, Balance)' as any,
 };
 
+// Returns liquidity volume, core amount, asset amount for given asset
 const liquidityValue: RpcMethodOpt = {
   description: "Get the value of an account's liquidity for the given asset",
   isOptional: true,

--- a/packages/api/test/e2e/api.calls.e2e.ts
+++ b/packages/api/test/e2e/api.calls.e2e.ts
@@ -32,17 +32,17 @@ describe('e2e api calls', () => {
     done();
   });
 
-  it('get correct block', async () => {
+  it('Get correct block', async () => {
     const block: Block = await api.rpc.chain.getBlock(blockHash).then((r: any) => r.block);
     expect(block.header.hash.toString()).toEqual(blockHash.toString());
   });
 
-  it('get correct validators', async () => {
+  it('Get correct validators', async () => {
     const validators: AccountId[] = (await api.query.session.validators.at(blockHash)) as any;
     expect(validators.length).toBeGreaterThan(0);
   });
 
-  it('expect author is in validators', async () => {
+  it('Expect author is in validators', async () => {
     const block: Block = await api.rpc.chain.getBlock(blockHash).then((r: any) => r.block);
     const header = block.header;
     const validators: AccountId[] = (await api.query.session.validators.at(blockHash)) as any;
@@ -51,13 +51,13 @@ describe('e2e api calls', () => {
     expect(validators).toEqual(expect.arrayContaining([expect.objectContaining(author)]));
   });
 
-  it('expect at least one event', async () => {
+  it('Expect at least one event', async () => {
     const events: EventRecord[] = (await api.query.system.events.at(blockHash)) as any;
     expect(events.length).toBeGreaterThan(0);
   });
 
   describe('Get session info', () => {
-    it('get correct session information (length, last length, era, current index, session per era', async () => {
+    it('Get correct session information (length, last length, era, current index, session per era', async () => {
       const currentSession = await api.derive.session.info();
       expect(currentSession.currentEra.toNumber()).toBeGreaterThanOrEqual(0);
       expect(currentSession.currentIndex.toNumber()).toBeGreaterThanOrEqual(0);
@@ -72,12 +72,12 @@ describe('e2e api calls', () => {
   });
 
   describe('Get core asset id', () => {
-    it('get correct spending asset id', async () => {
+    it('Get correct spending asset id', async () => {
       const spendingAssetId = (await api.query.genericAsset.spendingAssetId.at(blockHash)) as AssetId;
       expect(spendingAssetId.gtn(0)).toBeTruthy();
     });
 
-    it('get correct staking asset id', async () => {
+    it('Get correct staking asset id', async () => {
       const stakingAssetId = (await api.query.genericAsset.stakingAssetId.at(blockHash)) as AssetId;
       expect(stakingAssetId.gtn(0)).toBeTruthy();
     });

--- a/packages/api/test/e2e/api.create.e2e.ts
+++ b/packages/api/test/e2e/api.create.e2e.ts
@@ -14,7 +14,6 @@
 
 import {Api} from '../../src/Api';
 import staticMetadata from '../../src/staticMetadata';
-import initApiPromise from '../../../../jest/initApiPromise';
 import config from '../../../../config';
 import { Metadata } from '@cennznet/types';
 

--- a/packages/api/test/e2e/api.create.e2e.ts
+++ b/packages/api/test/e2e/api.create.e2e.ts
@@ -40,7 +40,7 @@ describe('e2e api create', () => {
     } catch (e) {}
   });
 
-  it('should create an Api instance with the timeout option', async () => {
+  it('Should create an Api instance with the timeout option', async () => {
     const provider = config.wsProvider[`${process.env.TEST_TYPE}`];
     api = await Api.create({provider, timeout: 1000000});
 
@@ -49,13 +49,13 @@ describe('e2e api create', () => {
     expect(hash).toBeDefined();
   });
 
-  it('should get rejected if the connection fails', async () => {
+  it('Should get rejected if the connection fails', async () => {
     const incorrectEndPoint = 'wss://rimu.unfrastructure.io/private/ws';
     await expect(Api.create({provider: incorrectEndPoint})).rejects.toThrow(
       'Connection fail');
   });
 
-  it('should get rejected if it is not resolved in a specific period of time', async () => {
+  it('Should get rejected if it is not resolved in a specific period of time', async () => {
     const provider = config.wsProvider[`${process.env.TEST_TYPE}`];
     await expect(Api.create({provider, timeout: 1})).rejects.toThrow(
       'Timed out in 1 ms.');

--- a/packages/api/test/e2e/cennzx.e2e.ts
+++ b/packages/api/test/e2e/cennzx.e2e.ts
@@ -28,7 +28,7 @@ describe('CENNZX e2e queries/transactions', () => {
         const amount = 3_000_000;
         const coreAmount = amount;
         const minLiquidity = 1;
-        await api.tx.cennzxSpot
+        await api.tx.cennzx
           .addLiquidity(CENNZ, minLiquidity, amount, coreAmount)
           .signAndSend(alice, async ({events, status}) => {
             if (status.isFinalized) {
@@ -36,7 +36,7 @@ describe('CENNZX e2e queries/transactions', () => {
                 if (event.method === 'AddLiquidity') {
                   let amount = 20000;
                   const [coreAmount, investmentAmount] = await api.rpc.cennzx.liquidityPrice(CENNZ, amount);
-                  await api.tx.cennzxSpot
+                  await api.tx.cennzx
                       .addLiquidity(CENNZ, minLiquidity, investmentAmount, coreAmount)
                       .signAndSend(alice, async ({events, status}) => {
                         if (status.isFinalized) {
@@ -64,8 +64,8 @@ describe('CENNZX e2e queries/transactions', () => {
     describe('Positive flow with liquidity in pool', () => {
       it("Calculate the buy price when buying CENTRAPAY for CENNZ", async done => {
         const amount = 100;
-        const poolAssetBalance = await api.derive.cennzxSpot.poolAssetBalance(CENNZ);
-        const poolCoreAssetBalance = await api.derive.cennzxSpot.poolCoreAssetBalance(CENNZ);
+        const poolAssetBalance = await api.derive.cennzx.poolAssetBalance(CENNZ);
+        const poolCoreAssetBalance = await api.derive.cennzx.poolCoreAssetBalance(CENNZ);
         console.log('Amount of asset in CENNZ pool:', poolAssetBalance.toString());
         console.log('Amount of core in CENNZ pool:', poolCoreAssetBalance.toString());
         // How much CENTRAPAY will it cost to buy 100 (amount) CENNZ
@@ -129,8 +129,8 @@ describe('CENNZX e2e queries/transactions', () => {
     describe('Negative flow with no liquidity in pool', () => {
       it("Calculate the buy price when buying CENTRAPAY for PLUG", async done => {
         const amount = 100;
-        const poolAssetBalance = await api.derive.cennzxSpot.poolAssetBalance(PLUG);
-        const poolCoreAssetBalance = await api.derive.cennzxSpot.poolCoreAssetBalance(PLUG);
+        const poolAssetBalance = await api.derive.cennzx.poolAssetBalance(PLUG);
+        const poolCoreAssetBalance = await api.derive.cennzx.poolCoreAssetBalance(PLUG);
         console.log('Amount of asset in PLUG pool:', poolAssetBalance.toString());
         console.log('Amount of core in PLUG pool:', poolCoreAssetBalance.toString());
         // How much CENTRAPAY will it cost to buy 100 (amount) PLUG

--- a/packages/api/test/e2e/cennzx.e2e.ts
+++ b/packages/api/test/e2e/cennzx.e2e.ts
@@ -28,7 +28,7 @@ describe('CENNZX e2e queries/transactions', () => {
         const amount = 3_000_000;
         const coreAmount = amount;
         const minLiquidity = 1;
-        await api.tx.cennzx
+        await api.tx.cennzxSpot
           .addLiquidity(CENNZ, minLiquidity, amount, coreAmount)
           .signAndSend(alice, async ({events, status}) => {
             if (status.isFinalized) {
@@ -36,7 +36,7 @@ describe('CENNZX e2e queries/transactions', () => {
                 if (event.method === 'AddLiquidity') {
                   let amount = 20000;
                   const [coreAmount, investmentAmount] = await api.rpc.cennzx.liquidityPrice(CENNZ, amount);
-                  await api.tx.cennzx
+                  await api.tx.cennzxSpot
                       .addLiquidity(CENNZ, minLiquidity, investmentAmount, coreAmount)
                       .signAndSend(alice, async ({events, status}) => {
                         if (status.isFinalized) {
@@ -64,8 +64,8 @@ describe('CENNZX e2e queries/transactions', () => {
     describe('Positive flow with liquidity in pool', () => {
       it("Calculate the buy price when buying CENTRAPAY for CENNZ", async done => {
         const amount = 100;
-        const poolAssetBalance = await api.derive.cennzx.poolAssetBalance(CENNZ);
-        const poolCoreAssetBalance = await api.derive.cennzx.poolCoreAssetBalance(CENNZ);
+        const poolAssetBalance = await api.derive.cennzxSpot.poolAssetBalance(CENNZ);
+        const poolCoreAssetBalance = await api.derive.cennzxSpot.poolCoreAssetBalance(CENNZ);
         console.log('Amount of asset in CENNZ pool:', poolAssetBalance.toString());
         console.log('Amount of core in CENNZ pool:', poolCoreAssetBalance.toString());
         // How much CENTRAPAY will it cost to buy 100 (amount) CENNZ
@@ -129,8 +129,8 @@ describe('CENNZX e2e queries/transactions', () => {
     describe('Negative flow with no liquidity in pool', () => {
       it("Calculate the buy price when buying CENTRAPAY for PLUG", async done => {
         const amount = 100;
-        const poolAssetBalance = await api.derive.cennzx.poolAssetBalance(PLUG);
-        const poolCoreAssetBalance = await api.derive.cennzx.poolCoreAssetBalance(PLUG);
+        const poolAssetBalance = await api.derive.cennzxSpot.poolAssetBalance(PLUG);
+        const poolCoreAssetBalance = await api.derive.cennzxSpot.poolCoreAssetBalance(PLUG);
         console.log('Amount of asset in PLUG pool:', poolAssetBalance.toString());
         console.log('Amount of core in PLUG pool:', poolCoreAssetBalance.toString());
         // How much CENTRAPAY will it cost to buy 100 (amount) PLUG

--- a/packages/api/test/e2e/queries.e2e.ts
+++ b/packages/api/test/e2e/queries.e2e.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import { AssetInfo, AssetOptions, BalanceLock, Vec, WithdrawReasons } from '@cennznet/types';
-import { Keyring } from '@polkadot/api';
 import testKeyring from '@polkadot/keyring/testing';
 import { Hash } from '@cennznet/types/interfaces';
 import { u8aToString } from '@polkadot/util';

--- a/packages/api/test/e2e/rxapi.create.e2e.ts
+++ b/packages/api/test/e2e/rxapi.create.e2e.ts
@@ -31,7 +31,7 @@ describe('e2e rx api create', () => {
     incorrectApiRx = null;
     done();
   });
-  it('should create an Api instance with the timeout option', async done => {
+  it('Should create an Api instance with the timeout option', async done => {
     const api = await apiRx.toPromise();
 
     api.rpc.chain.getBlockHash().subscribe(hash => {
@@ -40,7 +40,7 @@ describe('e2e rx api create', () => {
     });
   });
 
-  it('should create Api without timeout if timeout is 0', async done => {
+  it('Should create Api without timeout if timeout is 0', async done => {
     const api = await apiRx.toPromise();
     api.rpc.chain.getBlockHash().subscribe(hash => {
       expect(hash).toBeDefined();
@@ -48,11 +48,11 @@ describe('e2e rx api create', () => {
     });
   });
 
-  it('should get error if the connection fails', async () => {
+  it('Should get error if the connection fails', async () => {
     await expect(incorrectApiRx.toPromise()).rejects.toThrow(/Connection fail/);
   });
 
-  it('should get rejected if it is not resolved in a specific period of time', async () => {
+  it('Should get rejected if it is not resolved in a specific period of time', async () => {
     incorrectApiRx = await ApiRx.create({timeout: -1});
 
     await expect(incorrectApiRx.toPromise()).rejects.toThrow(/Timeout has occurred/);

--- a/packages/api/test/e2e/rxapi.queries.e2e.ts
+++ b/packages/api/test/e2e/rxapi.queries.e2e.ts
@@ -35,7 +35,7 @@ describe('e2e queries', () => {
   });
 
   describe('Query storage using at', () => {
-    it('queries correct balance', async done => {
+    it('Queries correct balance', async done => {
       const nextAssetId$ = api.rpc.chain
         .getBlockHash()
         .pipe(switchMap(blockHash => api.query.genericAsset.nextAssetId.at(blockHash as Hash)));

--- a/packages/api/test/e2e/staking.e2e.ts
+++ b/packages/api/test/e2e/staking.e2e.ts
@@ -64,7 +64,7 @@ describe('Staking Operations', () => {
 
   });
 
-  test('bond locks caller funds and assigns a controller account', async done => {
+  test('Bond locks caller funds and assigns a controller account', async done => {
     const bond = (await api.query.staking.minimumBond()) + 12_345;
 
     await api.tx.staking.bond(controller.address, bond, 'controller').signAndSend(stash, async ({ status }) => {
@@ -81,7 +81,7 @@ describe('Staking Operations', () => {
 
   });
 
-  test('bond extra locks additional funds', async done => {
+  test('Bond extra locks additional funds', async done => {
 
     const additionalBond = 333;
     const previousLedger = ((await api.query.staking.ledger(controller.address)) as Option<StakingLedger>).unwrap();
@@ -97,7 +97,7 @@ describe('Staking Operations', () => {
     await api.tx.staking.bondExtra(additionalBond).signAndSend(stash);
   });
 
-  test('unbond schedules some funds to unlock', async done => {
+  test('Unbond schedules some funds to unlock', async done => {
     const unbondAmount = 500;
     const previousLedger = ((await api.query.staking.ledger(controller.address)) as Option<StakingLedger>).unwrap();
 
@@ -113,7 +113,7 @@ describe('Staking Operations', () => {
   });
 
   /// Rebond a portion of the stash scheduled to be unlocked.
-  test('rebond locks funds again', async done => {
+  test('Rebond locks funds again', async done => {
     const rebondAmount = 300;
     const previousLedger = ((await api.query.staking.ledger(controller.address)) as Option<StakingLedger>).unwrap();
 
@@ -128,7 +128,7 @@ describe('Staking Operations', () => {
     await api.tx.staking.rebond(rebondAmount).signAndSend(controller);
   });
 
-  test('withdraw unbonded', async done => {
+  test('Withdraw unbonded', async done => {
     await api.tx.staking.withdrawUnbonded().signAndSend(controller, ({ status, events }) => {
       if (status.isInBlock) {
         expect(
@@ -139,7 +139,7 @@ describe('Staking Operations', () => {
     });
   });
 
-  test('validate adds stash as a validator candidate', async done => {
+  test('Validate adds stash as a validator candidate', async done => {
     // parts per billion
     // 100,000,000 / 1,000,000,000 == 0.1%
     const commission = 1_000_000_000;
@@ -155,7 +155,7 @@ describe('Staking Operations', () => {
     await api.tx.staking.validate({ commission }).signAndSend(controller, checkCommission);
   });
 
-  test('chill removes stash from validator candidacy', async done => {
+  test('Chill removes stash from validator candidacy', async done => {
 
     const checkCommission = async ({ status }) => {
       if (status.isInBlock) {

--- a/packages/api/test/e2e/tx.e2e.ts
+++ b/packages/api/test/e2e/tx.e2e.ts
@@ -145,7 +145,7 @@ describe('e2e transactions', () => {
         const minimumLiquidity = 1;
         const [coreInvestment, feeInvestment] = await (api.rpc as any).cennzx.liquidityPrice(feeAssetId, desiredLiquidity);
 
-        await api.tx.cennzxSpot
+        await api.tx.cennzx
           .addLiquidity(feeAssetId, minimumLiquidity, feeInvestment, coreInvestment)
           .signAndSend(assetOwner, ({ status }) => status.isInBlock ? done() : null);
       });

--- a/packages/api/test/e2e/tx.e2e.ts
+++ b/packages/api/test/e2e/tx.e2e.ts
@@ -44,7 +44,7 @@ describe('e2e transactions', () => {
 
   describe('Send', () => {
 
-    it('makes a tx using immortal era', async done => {
+    it('Makes a tx using immortal era', async done => {
       const nonce = await api.query.system.accountNonce(bob.address);
       await api.tx.genericAsset
         .transfer(stakingAssetId, alice.address, 100)
@@ -58,7 +58,7 @@ describe('e2e transactions', () => {
           });
     });
 
-    it('makes a tx via send', async done => {
+    it('Makes a tx via send', async done => {
       const nonce = await api.query.system.accountNonce(bob.address);
       const tx = api.tx.genericAsset
         .transfer(stakingAssetId, alice.address, 1)
@@ -72,7 +72,7 @@ describe('e2e transactions', () => {
       });
     });
 
-    it('makes a tx', async done => {
+    it('Makes a tx', async done => {
       const nonce = await api.query.system.accountNonce(bob.address);
       await api.tx.genericAsset
         .transfer(stakingAssetId, alice.address, 1)
@@ -152,7 +152,7 @@ describe('e2e transactions', () => {
 
     });
 
-    it('uses keypair to sign', async done => {
+    it('Uses keypair to sign', async done => {
       const feeExchange = {
         FeeExchangeV1: {
           assetId: feeAssetId,
@@ -173,7 +173,7 @@ describe('e2e transactions', () => {
         );
     });
 
-    it('use signer', async done => {
+    it('Use signer', async done => {
       const feeExchange = {
         FeeExchangeV1: {
           assetId: feeAssetId,
@@ -193,7 +193,7 @@ describe('e2e transactions', () => {
       );
     });
 
-    it('update asset info', async done => {
+    it('Update asset info', async done => {
       const nonce = await api.query.system.accountNonce(assetOwner.address);
       await api.tx.genericAsset.updateAssetInfo(
         feeAssetId,

--- a/packages/api/test/e2e/tx.e2e.ts
+++ b/packages/api/test/e2e/tx.e2e.ts
@@ -145,7 +145,7 @@ describe('e2e transactions', () => {
         const minimumLiquidity = 1;
         const [coreInvestment, feeInvestment] = await (api.rpc as any).cennzx.liquidityPrice(feeAssetId, desiredLiquidity);
 
-        await api.tx.cennzx
+        await api.tx.cennzxSpot
           .addLiquidity(feeAssetId, minimumLiquidity, feeInvestment, coreInvestment)
           .signAndSend(assetOwner, ({ status }) => status.isInBlock ? done() : null);
       });

--- a/packages/crml-attestation/src/Attestation.ts
+++ b/packages/crml-attestation/src/Attestation.ts
@@ -48,6 +48,13 @@ export class Attestation {
     return this.api.derive.attestation.getClaim;
   }
 
+  /**
+   * @deprecated use getClaimList() instead
+   */
+  get getClaims(): QueryableGetClaims {
+    return this.api.derive.attestation.getClaims;
+  }
+
   get getClaimList(): QueryableGetClaimList {
     return this.api.derive.attestation.claims;
   }

--- a/packages/crml-attestation/src/Attestation.ts
+++ b/packages/crml-attestation/src/Attestation.ts
@@ -48,13 +48,6 @@ export class Attestation {
     return this.api.derive.attestation.getClaim;
   }
 
-  /**
-   * @deprecated use getClaimList() instead
-   */
-  get getClaims(): QueryableGetClaims {
-    return this.api.derive.attestation.getClaims;
-  }
-
   get getClaimList(): QueryableGetClaimList {
     return this.api.derive.attestation.claims;
   }

--- a/packages/crml-attestation/src/AttestationRx.ts
+++ b/packages/crml-attestation/src/AttestationRx.ts
@@ -49,6 +49,13 @@ export class AttestationRx {
     return this.api.derive.attestation.getClaim;
   }
 
+  /**
+   * @deprecated use getClaimList() instead
+   */
+  get getClaims(): QueryableGetClaimsRx {
+    return this.api.derive.attestation.getClaims;
+  }
+
   get getClaimList(): QueryableGetClaimListRx {
     return this.api.derive.attestation.claims;
   }

--- a/packages/crml-attestation/src/AttestationRx.ts
+++ b/packages/crml-attestation/src/AttestationRx.ts
@@ -49,13 +49,6 @@ export class AttestationRx {
     return this.api.derive.attestation.getClaim;
   }
 
-  /**
-   * @deprecated use getClaimList() instead
-   */
-  get getClaims(): QueryableGetClaimsRx {
-    return this.api.derive.attestation.getClaims;
-  }
-
   get getClaimList(): QueryableGetClaimListRx {
     return this.api.derive.attestation.claims;
   }

--- a/packages/crml-cennzx-spot/src/CennzxSpot.ts
+++ b/packages/crml-cennzx-spot/src/CennzxSpot.ts
@@ -146,8 +146,8 @@ export class CennzxSpot {
    * @param assetId
    */
   get getTotalLiquidity(): QueryableTotalLiquidityBalance {
-    const _fn = this.api.derive.cennzx.totalLiquidity as QueryableTotalLiquidityBalance;
-    _fn.at = this.api.derive.cennzx.totalLiquidityAt;
+    const _fn = this.api.derive.cennzxSpot.totalLiquidity as QueryableTotalLiquidityBalance;
+    _fn.at = this.api.derive.cennzxSpot.totalLiquidityAt;
 
     return _fn;
   }
@@ -165,8 +165,8 @@ export class CennzxSpot {
    * @param address The address of the account
    */
   get getLiquidityBalance(): QueryableGetLiquidityBalance {
-    const _fn = this.api.derive.cennzx.liquidityBalance as QueryableGetLiquidityBalance;
-    _fn.at = this.api.derive.cennzx.liquidityBalanceAt;
+    const _fn = this.api.derive.cennzxSpot.liquidityBalance as QueryableGetLiquidityBalance;
+    _fn.at = this.api.derive.cennzxSpot.liquidityBalanceAt;
 
     return _fn;
   }
@@ -176,8 +176,8 @@ export class CennzxSpot {
    * @param assetId The id of the asset
    */
   get getPoolAssetBalance(): QueryableGetPoolBalance {
-    const _fn = this.api.derive.cennzx.poolAssetBalance as QueryableGetPoolBalance;
-    _fn.at = this.api.derive.cennzx.poolAssetBalanceAt;
+    const _fn = this.api.derive.cennzxSpot.poolAssetBalance as QueryableGetPoolBalance;
+    _fn.at = this.api.derive.cennzxSpot.poolAssetBalanceAt;
 
     return _fn;
   }
@@ -187,8 +187,8 @@ export class CennzxSpot {
    * @param assetId The id of the asset
    */
   get getPoolCoreAssetBalance(): QueryableGetPoolBalance {
-    const _fn = this.api.derive.cennzx.poolCoreAssetBalance as QueryableGetPoolBalance;
-    _fn.at = this.api.derive.cennzx.poolCoreAssetBalanceAt;
+    const _fn = this.api.derive.cennzxSpot.poolCoreAssetBalance as QueryableGetPoolBalance;
+    _fn.at = this.api.derive.cennzxSpot.poolCoreAssetBalanceAt;
 
     return _fn;
   }
@@ -199,8 +199,8 @@ export class CennzxSpot {
    * @param liquidity - user liquidity
    */
   get getAssetToWithdraw(): QueryableGetAssetWithdrawn {
-    const _fn = this.api.derive.cennzx.assetToWithdraw as QueryableGetAssetWithdrawn;
-    _fn.at = this.api.derive.cennzx.assetToWithdraw;
+    const _fn = this.api.derive.cennzxSpot.assetToWithdraw as QueryableGetAssetWithdrawn;
+    _fn.at = this.api.derive.cennzxSpot.assetToWithdraw;
 
     return _fn;
   }

--- a/packages/crml-cennzx-spot/src/CennzxSpot.ts
+++ b/packages/crml-cennzx-spot/src/CennzxSpot.ts
@@ -86,7 +86,7 @@ export class CennzxSpot {
     amountBought: AnyNumber,
     maxAmountSold: AnyNumber
   ): SubmittableExtrinsic<'promise'> {
-    return this.api.tx.cennzxSpot.assetSwapOutput(null, assetSold, assetBought, amountBought, maxAmountSold);
+    return this.api.tx.cennzxSpot.buyAsset(null, assetSold, assetBought, amountBought, maxAmountSold);
   }
 
   /**
@@ -104,7 +104,7 @@ export class CennzxSpot {
     amountBought: AnyNumber,
     maxAmountSold: AnyNumber
   ): SubmittableExtrinsic<'promise'> {
-    return this.api.tx.cennzxSpot.assetSwapOutput(recipient, assetSold, assetBought, amountBought, maxAmountSold);
+    return this.api.tx.cennzxSpot.buyAsset(recipient, assetSold, assetBought, amountBought, maxAmountSold);
   }
 
   /**
@@ -120,7 +120,7 @@ export class CennzxSpot {
     amountSell: AnyNumber,
     minReceive: AnyNumber
   ): SubmittableExtrinsic<'promise'> {
-    return this.api.tx.cennzxSpot.assetSwapInput(null, assetSold, assetBought, amountSell, minReceive);
+    return this.api.tx.cennzxSpot.sellAsset(null, assetSold, assetBought, amountSell, minReceive);
   }
 
   /**
@@ -138,7 +138,7 @@ export class CennzxSpot {
     amountSell: AnyNumber,
     minReceive: AnyNumber
   ): SubmittableExtrinsic<'promise'> {
-    return this.api.tx.cennzxSpot.assetSwapInput(recipient, assetSold, assetBought, amountSell, minReceive);
+    return this.api.tx.cennzxSpot.sellAsset(recipient, assetSold, assetBought, amountSell, minReceive);
   }
 
   /**
@@ -198,7 +198,7 @@ export class CennzxSpot {
    * @param assetId The id of the asset
    * @param liquidity - user liquidity
    */
-  get assetToWithdraw(): QueryableGetAssetWithdrawn {
+  get getAssetToWithdraw(): QueryableGetAssetWithdrawn {
     const _fn = this.api.derive.cennzxSpot.assetToWithdraw as QueryableGetAssetWithdrawn;
     _fn.at = this.api.derive.cennzxSpot.assetToWithdraw;
 

--- a/packages/crml-cennzx-spot/src/CennzxSpot.ts
+++ b/packages/crml-cennzx-spot/src/CennzxSpot.ts
@@ -146,8 +146,8 @@ export class CennzxSpot {
    * @param assetId
    */
   get getTotalLiquidity(): QueryableTotalLiquidityBalance {
-    const _fn = this.api.derive.cennzxSpot.totalLiquidity as QueryableTotalLiquidityBalance;
-    _fn.at = this.api.derive.cennzxSpot.totalLiquidityAt;
+    const _fn = this.api.derive.cennzx.totalLiquidity as QueryableTotalLiquidityBalance;
+    _fn.at = this.api.derive.cennzx.totalLiquidityAt;
 
     return _fn;
   }
@@ -165,8 +165,8 @@ export class CennzxSpot {
    * @param address The address of the account
    */
   get getLiquidityBalance(): QueryableGetLiquidityBalance {
-    const _fn = this.api.derive.cennzxSpot.liquidityBalance as QueryableGetLiquidityBalance;
-    _fn.at = this.api.derive.cennzxSpot.liquidityBalanceAt;
+    const _fn = this.api.derive.cennzx.liquidityBalance as QueryableGetLiquidityBalance;
+    _fn.at = this.api.derive.cennzx.liquidityBalanceAt;
 
     return _fn;
   }
@@ -176,8 +176,8 @@ export class CennzxSpot {
    * @param assetId The id of the asset
    */
   get getPoolAssetBalance(): QueryableGetPoolBalance {
-    const _fn = this.api.derive.cennzxSpot.poolAssetBalance as QueryableGetPoolBalance;
-    _fn.at = this.api.derive.cennzxSpot.poolAssetBalanceAt;
+    const _fn = this.api.derive.cennzx.poolAssetBalance as QueryableGetPoolBalance;
+    _fn.at = this.api.derive.cennzx.poolAssetBalanceAt;
 
     return _fn;
   }
@@ -187,8 +187,8 @@ export class CennzxSpot {
    * @param assetId The id of the asset
    */
   get getPoolCoreAssetBalance(): QueryableGetPoolBalance {
-    const _fn = this.api.derive.cennzxSpot.poolCoreAssetBalance as QueryableGetPoolBalance;
-    _fn.at = this.api.derive.cennzxSpot.poolCoreAssetBalanceAt;
+    const _fn = this.api.derive.cennzx.poolCoreAssetBalance as QueryableGetPoolBalance;
+    _fn.at = this.api.derive.cennzx.poolCoreAssetBalanceAt;
 
     return _fn;
   }
@@ -199,8 +199,8 @@ export class CennzxSpot {
    * @param liquidity - user liquidity
    */
   get getAssetToWithdraw(): QueryableGetAssetWithdrawn {
-    const _fn = this.api.derive.cennzxSpot.assetToWithdraw as QueryableGetAssetWithdrawn;
-    _fn.at = this.api.derive.cennzxSpot.assetToWithdraw;
+    const _fn = this.api.derive.cennzx.assetToWithdraw as QueryableGetAssetWithdrawn;
+    _fn.at = this.api.derive.cennzx.assetToWithdraw;
 
     return _fn;
   }

--- a/packages/crml-cennzx-spot/src/CennzxSpotRx.ts
+++ b/packages/crml-cennzx-spot/src/CennzxSpotRx.ts
@@ -201,7 +201,7 @@ export class CennzxSpotRx {
    * @param assetId The id of the asset
    * @param liquidity - user liquidity
    */
-  get assetToWithdraw(): QueryableGetAssetWithdrawnRx {
+  get getAssetToWithdraw(): QueryableGetAssetWithdrawnRx {
     const _fn = this.api.derive.cennzxSpot.assetToWithdraw as QueryableGetAssetWithdrawnRx;
     _fn.at = this.api.derive.cennzxSpot.assetToWithdraw;
 

--- a/packages/crml-cennzx-spot/src/CennzxSpotRx.ts
+++ b/packages/crml-cennzx-spot/src/CennzxSpotRx.ts
@@ -146,8 +146,8 @@ export class CennzxSpotRx {
    * @param assetId
    */
   get getTotalLiquidity(): QueryableTotalLiquidityBalanceRx {
-    const _fn = this.api.derive.cennzx.totalLiquidity as QueryableTotalLiquidityBalanceRx;
-    _fn.at = this.api.derive.cennzx.totalLiquidityAt;
+    const _fn = this.api.derive.cennzxSpot.totalLiquidity as QueryableTotalLiquidityBalanceRx;
+    _fn.at = this.api.derive.cennzxSpot.totalLiquidityAt;
 
     return _fn;
   }
@@ -166,8 +166,8 @@ export class CennzxSpotRx {
    * @param {AnyAddress} address The address of the account
    */
   get getLiquidityBalance(): QueryableGetLiquidityBalanceRx {
-    const _fn = this.api.derive.cennzx.liquidityBalance as QueryableGetLiquidityBalanceRx;
-    _fn.at = this.api.derive.cennzx.liquidityBalanceAt;
+    const _fn = this.api.derive.cennzxSpot.liquidityBalance as QueryableGetLiquidityBalanceRx;
+    _fn.at = this.api.derive.cennzxSpot.liquidityBalanceAt;
 
     return _fn;
   }
@@ -178,8 +178,8 @@ export class CennzxSpotRx {
    * @param assetId The id of the asset
    */
   get getPoolAssetBalance(): QueryableGetPoolBalanceRx {
-    const _fn = this.api.derive.cennzx.poolAssetBalance as QueryableGetPoolBalanceRx;
-    _fn.at = this.api.derive.cennzx.poolAssetBalanceAt;
+    const _fn = this.api.derive.cennzxSpot.poolAssetBalance as QueryableGetPoolBalanceRx;
+    _fn.at = this.api.derive.cennzxSpot.poolAssetBalanceAt;
 
     return _fn;
   }
@@ -190,8 +190,8 @@ export class CennzxSpotRx {
    * @param assetId The id of the asset
    */
   get getPoolCoreAssetBalance(): QueryableGetPoolBalanceRx {
-    const _fn = this.api.derive.cennzx.poolCoreAssetBalance as QueryableGetPoolBalanceRx;
-    _fn.at = this.api.derive.cennzx.poolCoreAssetBalanceAt;
+    const _fn = this.api.derive.cennzxSpot.poolCoreAssetBalance as QueryableGetPoolBalanceRx;
+    _fn.at = this.api.derive.cennzxSpot.poolCoreAssetBalanceAt;
 
     return _fn;
   }
@@ -202,8 +202,8 @@ export class CennzxSpotRx {
    * @param liquidity - user liquidity
    */
   get getAssetToWithdraw(): QueryableGetAssetWithdrawnRx {
-    const _fn = this.api.derive.cennzx.assetToWithdraw as QueryableGetAssetWithdrawnRx;
-    _fn.at = this.api.derive.cennzx.assetToWithdraw;
+    const _fn = this.api.derive.cennzxSpot.assetToWithdraw as QueryableGetAssetWithdrawnRx;
+    _fn.at = this.api.derive.cennzxSpot.assetToWithdraw;
 
     return _fn;
   }

--- a/packages/crml-cennzx-spot/src/CennzxSpotRx.ts
+++ b/packages/crml-cennzx-spot/src/CennzxSpotRx.ts
@@ -146,8 +146,8 @@ export class CennzxSpotRx {
    * @param assetId
    */
   get getTotalLiquidity(): QueryableTotalLiquidityBalanceRx {
-    const _fn = this.api.derive.cennzxSpot.totalLiquidity as QueryableTotalLiquidityBalanceRx;
-    _fn.at = this.api.derive.cennzxSpot.totalLiquidityAt;
+    const _fn = this.api.derive.cennzx.totalLiquidity as QueryableTotalLiquidityBalanceRx;
+    _fn.at = this.api.derive.cennzx.totalLiquidityAt;
 
     return _fn;
   }
@@ -166,8 +166,8 @@ export class CennzxSpotRx {
    * @param {AnyAddress} address The address of the account
    */
   get getLiquidityBalance(): QueryableGetLiquidityBalanceRx {
-    const _fn = this.api.derive.cennzxSpot.liquidityBalance as QueryableGetLiquidityBalanceRx;
-    _fn.at = this.api.derive.cennzxSpot.liquidityBalanceAt;
+    const _fn = this.api.derive.cennzx.liquidityBalance as QueryableGetLiquidityBalanceRx;
+    _fn.at = this.api.derive.cennzx.liquidityBalanceAt;
 
     return _fn;
   }
@@ -178,8 +178,8 @@ export class CennzxSpotRx {
    * @param assetId The id of the asset
    */
   get getPoolAssetBalance(): QueryableGetPoolBalanceRx {
-    const _fn = this.api.derive.cennzxSpot.poolAssetBalance as QueryableGetPoolBalanceRx;
-    _fn.at = this.api.derive.cennzxSpot.poolAssetBalanceAt;
+    const _fn = this.api.derive.cennzx.poolAssetBalance as QueryableGetPoolBalanceRx;
+    _fn.at = this.api.derive.cennzx.poolAssetBalanceAt;
 
     return _fn;
   }
@@ -190,8 +190,8 @@ export class CennzxSpotRx {
    * @param assetId The id of the asset
    */
   get getPoolCoreAssetBalance(): QueryableGetPoolBalanceRx {
-    const _fn = this.api.derive.cennzxSpot.poolCoreAssetBalance as QueryableGetPoolBalanceRx;
-    _fn.at = this.api.derive.cennzxSpot.poolCoreAssetBalanceAt;
+    const _fn = this.api.derive.cennzx.poolCoreAssetBalance as QueryableGetPoolBalanceRx;
+    _fn.at = this.api.derive.cennzx.poolCoreAssetBalanceAt;
 
     return _fn;
   }
@@ -202,8 +202,8 @@ export class CennzxSpotRx {
    * @param liquidity - user liquidity
    */
   get getAssetToWithdraw(): QueryableGetAssetWithdrawnRx {
-    const _fn = this.api.derive.cennzxSpot.assetToWithdraw as QueryableGetAssetWithdrawnRx;
-    _fn.at = this.api.derive.cennzxSpot.assetToWithdraw;
+    const _fn = this.api.derive.cennzx.assetToWithdraw as QueryableGetAssetWithdrawnRx;
+    _fn.at = this.api.derive.cennzx.assetToWithdraw;
 
     return _fn;
   }

--- a/packages/crml-cennzx-spot/src/derives/assetWithdrawn.ts
+++ b/packages/crml-cennzx-spot/src/derives/assetWithdrawn.ts
@@ -22,6 +22,11 @@ import { getAssetToWithdraw } from '../utils/utils';
 import { poolAssetBalance, poolAssetBalanceAt, poolCoreAssetBalance, poolCoreAssetBalanceAt } from './poolBalance';
 import { totalLiquidity, totalLiquidityAt } from './totalLiquidity';
 
+/**
+ * Given an asset Id and liquidity amount, the function returns the core and asset that can be withdrawn from exchange
+ * @param assetId
+ * @param liquidty
+ */
 export function assetToWithdraw(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId, liquidity: AnyNumber): Observable<{ coreAmount: BN; assetAmount: BN }> => {
     return combineLatest([
@@ -36,6 +41,12 @@ export function assetToWithdraw(api: ApiInterfaceRx) {
   };
 }
 
+/**
+ * Given an asset Id and liquidity amount, the function returns the core and asset that can be withdrawn from exchange at a blockHash
+ * @param hash - blockHash
+ * @param assetId
+ * @param liquidty
+ */
 export function assetToWithdrawAt(api: ApiInterfaceRx) {
   return (hash: Hash, assetId: AnyAssetId, liquidity: AnyNumber): Observable<{ coreAmount: BN; assetAmount: BN }> => {
     return combineLatest([

--- a/packages/crml-cennzx-spot/src/derives/exchangeAddress.ts
+++ b/packages/crml-cennzx-spot/src/derives/exchangeAddress.ts
@@ -20,6 +20,10 @@ import { first, map } from 'rxjs/operators';
 import { generateExchangeAddress } from '../utils/utils';
 import { coreAssetId } from './shared';
 
+/**
+ * Returns the exchange address for a given assetId
+ @param assetId
+ */
 export function exchangeAddress(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId): Observable<string> =>
     coreAssetId(api)().pipe(

--- a/packages/crml-cennzx-spot/src/derives/liquidityBalance.ts
+++ b/packages/crml-cennzx-spot/src/derives/liquidityBalance.ts
@@ -22,6 +22,11 @@ import { switchMap } from 'rxjs/operators';
 import { getExchangeKey } from '../utils/utils';
 import { coreAssetId, coreAssetIdAt } from './shared';
 
+/**
+ * Gets the liquidity balance for an asset Id
+ * @param assetId
+ * @param address
+ */
 export function liquidityBalance(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId, address: AnyAddress): Observable<BN> => {
     return coreAssetId(api)().pipe(
@@ -37,6 +42,12 @@ export function liquidityBalance(api: ApiInterfaceRx) {
   };
 }
 
+/**
+ * Gets the liquidity balance for an asset Id at a given blockhash
+ * @param hash - blockHash
+ * @param assetId
+ * @param address
+ */
 export function liquidityBalanceAt(api: ApiInterfaceRx) {
   return (hash: Hash, assetId: AnyAssetId, address: AnyAddress): Observable<BN> => {
     return coreAssetIdAt(api)(hash).pipe(

--- a/packages/crml-cennzx-spot/src/derives/poolBalance.ts
+++ b/packages/crml-cennzx-spot/src/derives/poolBalance.ts
@@ -20,6 +20,10 @@ import { combineLatest, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { exchangeAddress } from './exchangeAddress';
 
+/**
+ * Returns the amount of asset in the exchange
+ * @param assetId
+ */
 export function poolAssetBalance(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId): Observable<any> => {
     return exchangeAddress(api)(assetId).pipe(
@@ -29,6 +33,10 @@ export function poolAssetBalance(api: ApiInterfaceRx) {
   };
 }
 
+/**
+ * Returns the amount of core asset in the exchange for the asset
+ * @param assetId
+ */
 export function poolCoreAssetBalance(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId): Observable<any> => {
     return combineLatest([exchangeAddress(api)(assetId), api.query.cennzxSpot.coreAssetId()]).pipe(
@@ -38,6 +46,11 @@ export function poolCoreAssetBalance(api: ApiInterfaceRx) {
   };
 }
 
+/**
+ * Returns the amount of asset in the exchange at a blockHash
+ * @param hash - blockHash
+ * @param assetId
+ */
 export function poolAssetBalanceAt(api: ApiInterfaceRx) {
   return (hash: Hash, assetId: AnyAssetId): Observable<any> => {
     return exchangeAddress(api)(assetId).pipe(
@@ -47,6 +60,11 @@ export function poolAssetBalanceAt(api: ApiInterfaceRx) {
   };
 }
 
+/**
+ * Returns the amount of core asset in the exchange for the asset at a blockHash
+ * @param hash - blockHash
+ * @param assetId
+ */
 export function poolCoreAssetBalanceAt(api: ApiInterfaceRx) {
   return (hash: Hash, assetId: AnyAssetId): Observable<any> => {
     return combineLatest([exchangeAddress(api)(assetId), api.query.cennzxSpot.coreAssetId()]).pipe(

--- a/packages/crml-cennzx-spot/src/derives/totalLiquidity.ts
+++ b/packages/crml-cennzx-spot/src/derives/totalLiquidity.ts
@@ -21,6 +21,10 @@ import { switchMap } from 'rxjs/operators';
 import { getExchangeKey } from '../utils/utils';
 import { coreAssetId, coreAssetIdAt } from './shared';
 
+/**
+ * Returns the total liqudity in the exchange for the asset
+ * @param assetId
+ */
 export function totalLiquidity(api: ApiInterfaceRx) {
   return (assetId: AnyAssetId): Observable<BN> => {
     return coreAssetId(api)().pipe(
@@ -32,6 +36,11 @@ export function totalLiquidity(api: ApiInterfaceRx) {
   };
 }
 
+/**
+ * Returns the total liqudity in the exchange for the asset at a blockHash
+ * @param hash - blockHash
+ * @param assetId
+ */
 export function totalLiquidityAt(api: ApiInterfaceRx) {
   return (hash: Hash, assetId: AnyAssetId): Observable<BN> => {
     return coreAssetIdAt(api)(hash).pipe(

--- a/packages/crml-cennzx-spot/src/utils/utils.ts
+++ b/packages/crml-cennzx-spot/src/utils/utils.ts
@@ -17,8 +17,6 @@ import { AnyAssetId, AnyNumber, Registry } from '@cennznet/types/types';
 import { blake2AsU8a, stringToU8a, u8aConcat } from '@cennznet/util';
 import BN from 'bn.js';
 
-import { MAX_U128, PERMILL_BASE, ROUND_UP } from '../constants';
-
 /**
  * Generate the key of the balance storage
  * @param prefixString
@@ -44,6 +42,13 @@ export function getExchangeKey(registry: Registry, coreAssetId: AnyAssetId, asse
   return new Tuple(registry, [AssetId, AssetId], [coreAssetId, assetId]);
 }
 
+/**
+ * get the amount of core asset and other asset that can be withdrawn for given liquidity amount
+ * @param liquidity
+ * @param coreReserve
+ * @param assetReserve
+ * @param totalLiquidity
+ */
 export function getAssetToWithdraw(liquidity: BN, coreReserve: BN, assetReserve: BN, totalLiquidity: BN) {
   if (liquidity.gt(totalLiquidity)) {
     throw new Error('Tried to overdraw liquidity');

--- a/packages/crml-cennzx-spot/test/spotx.e2e.ts
+++ b/packages/crml-cennzx-spot/test/spotx.e2e.ts
@@ -191,7 +191,7 @@ describe('SpotX APIs', () => {
             const totalLiquidityBefore = await api.cennzxSpot.getTotalLiquidity(tradeAssetA);
             const removeLiquidity = 10;
             expect(totalLiquidityBefore.gtn(removeLiquidity)).toBeTruthy();
-            const {coreAmount, assetAmount} = await api.cennzxSpot.assetToWithdraw(tradeAssetA, removeLiquidity);
+            const {coreAmount, assetAmount} = await api.cennzxSpot.getAssetToWithdraw(tradeAssetA, removeLiquidity);
             await api.cennzxSpot
                 .removeLiquidity(tradeAssetA, removeLiquidity, 1, 1)
                 .signAndSend(alice, async ({events, status}) => {

--- a/packages/types/src/Doughnut.ts
+++ b/packages/types/src/Doughnut.ts
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import logger from '@cennznet/api/util/logging';
-import Raw from '@polkadot/types/codec/Raw';
-import { AnyU8a, Registry } from '@polkadot/types/types';
+import { Raw } from '@cennznet/types';
+import { AnyU8a, Registry } from '@cennznet/types/types';
 
 /**
  * A v0 Doughnut certificate

--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -5,20 +5,18 @@
 // tslint:disable member-ordering no-magic-numbers
 
 import { ExtrinsicPayloadValueV2 } from '@cennznet/types/extrinsic/v2/ExtrinsicPayload';
-import { ClassOf, Compact, TypeRegistry } from '@polkadot/types';
+import { ClassOf, Compact } from '@cennznet/types';
 import Base from '@polkadot/types/codec/Base';
-import { Address, Balance, Call, EcdsaSignature, Ed25519Signature, Sr25519Signature } from '@polkadot/types/interfaces';
-import { FunctionMetadataLatest } from '@polkadot/types/interfaces/metadata';
 import {
-  AnyU8a,
-  ArgsDef,
-  Codec,
-  IExtrinsic,
-  IExtrinsicEra,
-  IHash,
-  IKeyringPair,
-  Registry,
-} from '@polkadot/types/types';
+  Address,
+  Balance,
+  Call,
+  EcdsaSignature,
+  Ed25519Signature,
+  Sr25519Signature,
+  FunctionMetadataLatest,
+} from '@cennznet/types/interfaces';
+import { AnyU8a, ArgsDef, Codec, IExtrinsic, IExtrinsicEra, IKeyringPair, Registry } from '@cennznet/types/types';
 import { assert, isHex, isU8a, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
 import { ChargeTransactionPayment, Index } from '../runtime';
 import { BIT_SIGNED, BIT_UNSIGNED, DEFAULT_VERSION } from './constants';

--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -4,10 +4,10 @@
 
 // tslint:disable member-ordering no-magic-numbers
 
-import { Compact, Raw, u32 } from '@polkadot/types';
+import { Compact, Raw, u32 } from '@cennznet/types';
 import Base from '@polkadot/types/codec/Base';
-import { Balance, Hash } from '@polkadot/types/interfaces/runtime';
-import { IExtrinsicEra, IKeyringPair, Registry } from '@polkadot/types/types';
+import { Balance, Hash } from '@cennznet/types/interfaces';
+import { IExtrinsicEra, IKeyringPair, Registry } from '@cennznet/types/types';
 
 import { u8aToHex } from '@polkadot/util';
 

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Compact, Option, Struct, u8 } from '@polkadot/types';
+import { Compact, Option, Struct, u8 } from '@cennznet/types';
 import {
   Address,
   Balance,
@@ -12,14 +12,14 @@ import {
   Hash,
   Index,
   RuntimeVersion,
-} from '@polkadot/types/interfaces';
+} from '@cennznet/types/interfaces';
 import {
   Codec,
   Constructor,
   ISignerPayload,
   SignerPayloadJSON as SignerPayloadJSONBase,
   SignerPayloadRaw,
-} from '@polkadot/types/types';
+} from '@cennznet/types/types';
 import { u8aToHex } from '@polkadot/util';
 
 import Doughnut from '../Doughnut';

--- a/packages/types/src/extrinsic/types.spec.ts
+++ b/packages/types/src/extrinsic/types.spec.ts
@@ -1,5 +1,5 @@
-import {TypeRegistry, createType} from '@polkadot/types';
-import {Phase} from './types';
+import { TypeRegistry, createType } from '@cennznet/types';
+import { Phase } from './types';
 
 const registry = new TypeRegistry();
 registry.register(Phase);

--- a/packages/types/src/extrinsic/types.ts
+++ b/packages/types/src/extrinsic/types.ts
@@ -12,19 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Enum } from '@polkadot/types';
-import { Option, Vec } from '@polkadot/types/codec';
+import { Enum, Option, Vec } from '@cennznet/types';
 import { InterfaceRegistry } from '@polkadot/types/interfaceRegistry';
-import {
-  AnyNumber,
-  AnyU8a,
-  IExtrinsicEra,
-  IExtrinsicImpl as IExtrinsicImplBase,
-  IMethod,
-  ITuple,
-  RuntimeVersionInterface,
-  SignatureOptions as SignatureOptionsBase,
-} from '@polkadot/types/types';
+import { AnyNumber, AnyU8a, IExtrinsicEra, IMethod, ITuple, RuntimeVersionInterface } from '@cennznet/types/types';
+import { SignatureOptions as SignatureOptionsBase } from '@polkadot/types/types';
 import { AccountId } from '@cennznet/types/interfaces';
 import Doughnut from '../Doughnut';
 import { AssetId, AssetInfo } from '../runtime/ga';

--- a/packages/types/src/extrinsic/v2/Extrinsic.ts
+++ b/packages/types/src/extrinsic/v2/Extrinsic.ts
@@ -14,12 +14,13 @@
 
 // tslint:disable member-ordering no-magic-numbers
 
-import { ClassOf, createType, Struct, TypeRegistry } from '@polkadot/types';
+import { ClassOf, createType, Struct } from '@cennznet/types';
 import { Address, Call } from '@polkadot/types/interfaces/runtime';
-import { IExtrinsicImpl, IKeyringPair, Registry, SignatureOptions } from '@polkadot/types/types';
+import { IExtrinsicImpl, IKeyringPair, Registry } from '@cennznet/types/types';
+import { SignatureOptions } from '@polkadot/types/types';
 import { isU8a } from '@polkadot/util';
-
 import { ExtrinsicOptions } from '../types';
+
 import { ExtrinsicPayloadValueV2 } from './ExtrinsicPayload';
 import ExtrinsicSignatureV2 from './ExtrinsicSignature';
 

--- a/packages/types/src/extrinsic/v2/Extrinsic.ts
+++ b/packages/types/src/extrinsic/v2/Extrinsic.ts
@@ -17,7 +17,7 @@
 import { ClassOf, createType, Struct, TypeRegistry } from '@polkadot/types';
 import { Address, Call } from '@polkadot/types/interfaces/runtime';
 import { IExtrinsicImpl, IKeyringPair, Registry, SignatureOptions } from '@polkadot/types/types';
-import { isU8a, u8aConcat } from '@polkadot/util';
+import { isU8a } from '@polkadot/util';
 
 import { ExtrinsicOptions } from '../types';
 import { ExtrinsicPayloadValueV2 } from './ExtrinsicPayload';

--- a/packages/types/src/extrinsic/v2/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v2/ExtrinsicPayload.ts
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 // tslint:disable member-ordering no-magic-numbers
-import { Bytes, Compact, Struct, u32, u64 } from '@polkadot/types';
-import { Balance, ExtrinsicEra, Hash } from '@polkadot/types/interfaces/runtime';
+import { Bytes, Compact, Struct, u32, Option } from '@cennznet/types';
+import { ExtrinsicEra } from '@cennznet/types/primitive';
 import { sign } from '@polkadot/types/primitive/Extrinsic/util';
-import { AnyNumber, AnyU8a, IExtrinsicEra, IKeyringPair, IMethod, Registry } from '@polkadot/types/types';
-import { u8aConcat } from '@polkadot/util';
+import { AnyNumber, AnyU8a, IExtrinsicEra, IKeyringPair, IMethod, Registry } from '@cennznet/types/types';
 
-import Option from '@polkadot/types/codec/Option';
+import { Balance, Hash } from '@cennznet/types/interfaces';
 import Doughnut from '../../Doughnut';
 import { ChargeTransactionPayment, Index } from '../../runtime';
 import { CennznetInterfaceTypes } from '../types';

--- a/packages/types/src/extrinsic/v2/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v2/ExtrinsicSignature.ts
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 // tslint:disable member-ordering no-magic-numbers
-import { Compact, createType, Struct, TypeRegistry } from '@polkadot/types';
-import Option from '@polkadot/types/codec/Option';
+import { Compact, createType, Struct, Option } from '@cennznet/types';
 import {
   Address,
   Balance,
@@ -24,14 +23,13 @@ import {
   ExtrinsicEra,
   MultiSignature,
   Sr25519Signature,
-} from '@polkadot/types/interfaces/runtime';
-import { ExtrinsicSignatureOptions } from '@polkadot/types/primitive/Extrinsic/types';
-import { IExtrinsicSignature, IKeyringPair, Registry } from '@polkadot/types/types';
+} from '@cennznet/types/interfaces';
+import { IExtrinsicSignature, IKeyringPair, Registry } from '@cennznet/types/types';
 import { u8aConcat } from '@polkadot/util';
 import Doughnut from '../../Doughnut';
 import { ChargeTransactionPayment, Index } from '../../runtime';
 import { EMPTY_U8A, IMMORTAL_ERA } from '../constants';
-import { ExtrinsicV2SignatureOptions } from '../types';
+import { ExtrinsicSignatureOptions, ExtrinsicV2SignatureOptions } from '../types';
 import ExtrinsicPayloadV2, { ExtrinsicPayloadValueV2 } from './ExtrinsicPayload';
 
 /**

--- a/packages/types/src/runtime/attestation/Topic.spec.ts
+++ b/packages/types/src/runtime/attestation/Topic.spec.ts
@@ -1,5 +1,5 @@
 import AttestationTopic from './Topic';
-import {TypeRegistry} from '@polkadot/types';
+import { TypeRegistry } from '@cennznet/types';
 
 const registry = new TypeRegistry();
 describe('AttestationTopic', () => {

--- a/packages/types/src/runtime/attestation/Topic.ts
+++ b/packages/types/src/runtime/attestation/Topic.ts
@@ -15,8 +15,8 @@
 /*
     Custom `Topic` type for Attestation module.
  */
-import { ClassOf, TypeRegistry } from '@polkadot/types';
-import { Registry } from '@polkadot/types/types';
+import { ClassOf, TypeRegistry } from '@cennznet/types';
+import { Registry } from '@cennznet/types/types';
 import { isHex, isString, stringToU8a, u8aToString } from '@polkadot/util';
 
 function isAscii(str: string) {

--- a/packages/types/src/runtime/attestation/Value.ts
+++ b/packages/types/src/runtime/attestation/Value.ts
@@ -15,7 +15,7 @@
 /*
     Custom `Value` type for Attestation module.
  */
-import { ClassOf, TypeRegistry } from '@polkadot/types';
+import { ClassOf, TypeRegistry } from '@cennznet/types';
 const registry = new TypeRegistry();
 
 export default class AttestationValue extends ClassOf(registry, 'H256') {}

--- a/packages/types/src/runtime/cennzx/ExchangeKey.ts
+++ b/packages/types/src/runtime/cennzx/ExchangeKey.ts
@@ -1,4 +1,4 @@
-import { Tuple } from '@polkadot/types';
+import { Tuple } from '@cennznet/types';
 
 import { AssetId } from '../ga';
 

--- a/packages/types/src/runtime/cennzx/FeeRate.ts
+++ b/packages/types/src/runtime/cennzx/FeeRate.ts
@@ -1,4 +1,4 @@
-import { ClassOf, TypeRegistry } from '@polkadot/types';
+import { ClassOf, TypeRegistry } from '@cennznet/types';
 
 const registry = new TypeRegistry();
 export default class FeeRate extends ClassOf(registry, 'u128') {

--- a/packages/types/src/runtime/cennzx/cennzx.spec.ts
+++ b/packages/types/src/runtime/cennzx/cennzx.spec.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {createTypeUnsafe, TypeRegistry} from '@polkadot/types';
+import { createTypeUnsafe, TypeRegistry } from '@cennznet/types';
 
 import * as cennzxTypes from './';
 import ExchangeKey from './ExchangeKey';
 import FeeRate from './FeeRate';
-import {IExchangeKey} from './types';
+import { IExchangeKey } from './types';
 
 const registry = new TypeRegistry();
 registry.register(cennzxTypes);

--- a/packages/types/src/runtime/cennzx/types.ts
+++ b/packages/types/src/runtime/cennzx/types.ts
@@ -1,4 +1,4 @@
-import { Codec } from '@polkadot/types/types';
+import { Codec } from '@cennznet/types/types';
 
 import AssetId from '../ga/AssetId';
 

--- a/packages/types/src/runtime/ga/AssetId.ts
+++ b/packages/types/src/runtime/ga/AssetId.ts
@@ -17,6 +17,6 @@
  @plugnet/types
 */
 
-import { u32 } from '@polkadot/types';
+import { u32 } from '@cennznet/types';
 
 export default u32;

--- a/packages/types/src/runtime/ga/AssetInfo.ts
+++ b/packages/types/src/runtime/ga/AssetInfo.ts
@@ -16,8 +16,8 @@
  Custom `AssetInfo` type for generic asset module.
 */
 
-import { Struct, u8, Vec } from '@polkadot/types';
-import { Registry } from '@polkadot/types/types';
+import { Struct, u8, Vec } from '@cennznet/types';
+import { Registry } from '@cennznet/types/types';
 
 export default class AssetInfo extends Struct {
   constructor(registry: Registry, value: any) {

--- a/packages/types/src/runtime/ga/AssetOptions.ts
+++ b/packages/types/src/runtime/ga/AssetOptions.ts
@@ -16,9 +16,9 @@
  Custom `AssetOptions` type for generic asset module.
 */
 
-import { Struct } from '@polkadot/types';
-import { Balance } from '@polkadot/types/interfaces';
-import { Registry } from '@polkadot/types/types';
+import { Struct } from '@cennznet/types';
+import { Balance } from '@cennznet/types/interfaces';
+import { Registry } from '@cennznet/types/types';
 import PermissionLatest from './PermissionsV1';
 
 export default class AssetOptions extends Struct {

--- a/packages/types/src/runtime/ga/BalanceLock.spec.ts
+++ b/packages/types/src/runtime/ga/BalanceLock.spec.ts
@@ -1,4 +1,4 @@
-import {createType, TypeRegistry} from '@polkadot/types';
+import { createType, TypeRegistry } from '@cennznet/types';
 
 import BalanceLock from './BalanceLock';
 

--- a/packages/types/src/runtime/ga/BalanceLock.ts
+++ b/packages/types/src/runtime/ga/BalanceLock.ts
@@ -1,6 +1,6 @@
-import { Struct } from '@polkadot/types';
-import { Balance, LockIdentifier } from '@polkadot/types/interfaces';
-import { Registry } from '@polkadot/types/types';
+import { Struct } from '@cennznet/types';
+import { Balance, LockIdentifier } from '@cennznet/types/interfaces';
+import { Registry } from '@cennznet/types/types';
 
 import { WithdrawReasons } from './';
 

--- a/packages/types/src/runtime/ga/Owner.ts
+++ b/packages/types/src/runtime/ga/Owner.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ClassOf, TypeRegistry } from '@polkadot/types';
+import { ClassOf, TypeRegistry } from '@cennznet/types';
 
 const registry = new TypeRegistry();
 export default class Owner extends ClassOf(registry, 'Option<AccountId>') {}

--- a/packages/types/src/runtime/ga/PermissionVersions.ts
+++ b/packages/types/src/runtime/ga/PermissionVersions.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Enum } from '@polkadot/types';
+import { Enum } from '@cennznet/types';
 import PermissionsV1 from './PermissionsV1';
 
 export default class PermissionVersions extends Enum.with({ PermissionsV1 }) {}

--- a/packages/types/src/runtime/ga/PermissionsV1.ts
+++ b/packages/types/src/runtime/ga/PermissionsV1.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Struct } from '@polkadot/types';
-import { Registry } from '@polkadot/types/types';
+import { Struct } from '@cennznet/types';
+import { Registry } from '@cennznet/types/types';
 import Owner from './Owner';
 
 /**

--- a/packages/types/src/runtime/ga/WithdrawReasons.spec.ts
+++ b/packages/types/src/runtime/ga/WithdrawReasons.spec.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {TypeRegistry} from '@polkadot/types';
+import { TypeRegistry } from '@cennznet/types';
 
 import WithdrawReasons from './WithdrawReasons';
 

--- a/packages/types/src/runtime/ga/WithdrawReasons.ts
+++ b/packages/types/src/runtime/ga/WithdrawReasons.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { i8 } from '@polkadot/types';
+import { i8 } from '@cennznet/types';
 
 // See: https://github.com/plugblockchain/plug-blockchain/blob/f580bbbb496f66655b27105e27e9d1e1d52bbb02/frame/support/src/traits.rs#L737-L756
 const ReasonMask = {

--- a/packages/types/src/runtime/ga/ga.spec.ts
+++ b/packages/types/src/runtime/ga/ga.spec.ts
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {createTypeUnsafe, TypeRegistry, u32} from '@polkadot/types';
+import { createTypeUnsafe, TypeRegistry } from '@cennznet/types';
 
 import * as gaTypes from './';
 import AssetOptions from './AssetOptions';
 import PermissionsV1 from './PermissionsV1';
-import ExchangeKey from '@cennznet/types/runtime/cennzx/ExchangeKey';
-import FeeRate from '@cennznet/types/runtime/cennzx/FeeRate';
 
 const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
 

--- a/packages/types/src/runtime/index.ts
+++ b/packages/types/src/runtime/index.ts
@@ -20,4 +20,4 @@ export * from './sylo';
 export * from './transaction-payment';
 
 // The CENNZnet nonce type
-export { u64 as Index } from '@polkadot/types';
+export { u64 as Index } from '@cennznet/types';

--- a/packages/types/src/runtime/staking/index.ts
+++ b/packages/types/src/runtime/staking/index.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Enum } from '@polkadot/types';
-import { Registry } from '@polkadot/types/types';
+import { Enum } from '@cennznet/types';
+import { Registry } from '@cennznet/types/types';
 import { AccountId } from '@cennznet/types/interfaces';
 
 // Specifies which account staking rewards should be paid too.

--- a/packages/types/src/runtime/staking/types.spec.ts
+++ b/packages/types/src/runtime/staking/types.spec.ts
@@ -1,5 +1,5 @@
-import {RewardDestination} from '.';
-import {TypeRegistry, createType} from '@polkadot/types';
+import { RewardDestination } from '.';
+import { TypeRegistry, createType } from '@cennznet/types';
 
 const registry = new TypeRegistry();
 registry.register(RewardDestination);
@@ -17,14 +17,14 @@ describe('RewardDestination', (): void => {
     expect(destinationControllerStr.isController).toBeTruthy();
 
     const destinationAccountAddress = '5FEe8Ht1ZTzNjQcvrxbLxnykA2EXfqN5LMog2gaNPus4tfZR';
-    const destinationAccount = createType(registry, 'RewardDestination', {account: destinationAccountAddress}, 2);
+    const destinationAccount = createType(registry, 'RewardDestination', { account: destinationAccountAddress }, 2);
     expect(destinationAccount.asAccount.toString()).toEqual(destinationAccountAddress);
     expect(destinationAccount.isAccount).toBeTruthy();
-    const destinationAccountStr = createType(registry, 'RewardDestination', {account: destinationAccountAddress});
+    const destinationAccountStr = createType(registry, 'RewardDestination', { account: destinationAccountAddress });
     expect(destinationAccountStr.asAccount.toString()).toEqual(destinationAccountAddress);
     expect(destinationAccountStr.isAccount).toBeTruthy();
 
-    const destinationPayee = new RewardDestination(registry, {account: destinationAccountAddress});
+    const destinationPayee = new RewardDestination(registry, { account: destinationAccountAddress });
     expect(destinationPayee.asAccount.toString()).toEqual(destinationAccountAddress);
     expect(destinationPayee.isAccount).toBeTruthy();
   });

--- a/packages/types/src/runtime/sylo/index.ts
+++ b/packages/types/src/runtime/sylo/index.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ClassOf, Enum, Null, Struct, Text, Tuple, TypeRegistry, Vec } from '@polkadot/types';
-import { Registry } from '@polkadot/types/types';
+import { ClassOf, Enum, Null, Struct, Text, Tuple, TypeRegistry, Vec } from '@cennznet/types';
+import { Registry } from '@cennznet/types/types';
 import { u8aToHex } from '@polkadot/util';
 
 const GROUP_JSON_MAP = new Map([['groupId', 'group_id']]);

--- a/packages/types/src/runtime/transaction-payment/index.ts
+++ b/packages/types/src/runtime/transaction-payment/index.ts
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Enum, Struct } from '@polkadot/types';
-import Compact from '@polkadot/types/codec/Compact';
-import Option from '@polkadot/types/codec/Option';
-import { AssetId, Balance } from '@polkadot/types/interfaces/runtime';
-import { Registry } from '@polkadot/types/types';
+import { Enum, Struct, Compact, Option } from '@cennznet/types';
+import { AssetId, Balance } from '@cennznet/types/interfaces';
+import { Registry } from '@cennznet/types/types';
 
 /* [[FeeExchangeV1]] when included in a transaction it indicates network fees should be
  * paid in `assetId` by paying up to `maxPayment` after the exchange rate is calculated.

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,6 +947,16 @@
   resolved "https://registry.yarnpkg.com/@cennznet/cennznut-wasm/-/cennznut-wasm-0.0.1-dev.0.tgz#ca14f8cdc24fc3865424303510492d96a166de0b"
   integrity sha512-twB1kO8SjdsGRf4epz7aq7LhELQky2ed9tVE8hB2VykXNwBvgJhmBdRDOu5HSSxwiR7WNdJk0LwPfVLnhE6W7g==
 
+"@cennznet/crml-cennzx-spot@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@cennznet/crml-cennzx-spot/-/crml-cennzx-spot-1.2.1.tgz#9fadab2420dd47b3f262113cd2c138ca3584a7b7"
+  integrity sha512-nHKX9NlNjxmPNbOvxhetqBm9/QvH5Jd6ZebDX+gaFolzLvk64aGgJ1EKnjcI/kf+7ORhHIjN+EP+Pnup/UO+rw==
+  dependencies:
+    "@cennznet/api" "^1.2.1"
+    "@cennznet/crml-generic-asset" "^1.2.1"
+    "@cennznet/types" "^1.2.1"
+    "@cennznet/util" "^1.2.1"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"


### PR DESCRIPTION
This PR is to make cennznet/api repo consistent

Updated/Added comments wherever required/missing
Removed unused imports
Updated api/test to look consistent
Updated polkadot/types to use cennznet/types inside cennznet/types

Few things need clarification 
1. The reason at some places we have cennzx and cennzxSpot... is because metadata has queries and extrinsic available at api.query.**cennzxSpot** / api.tx.**cennzxSpot** and it has rpc calls available at api.rpx.**cennzx**.buyPrice.
Do we plan to change on node side to have same name?
2. Attestation has a derived query marked as deprecated. Do we plan to remove those and the test that depends on them.

Haven't really found many places to update the public functions name.. Will revisit once more..


