### PR TITLE
Chore/update node image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   testnet_node_alice:
     container_name: testnet_node_alice
-    image: cennznet/cennznet:develop-1d31b4
+    image: cennznet/cennznet:update/2.0.0-1d31b4
     command:
       - --chain=dev
       - --base-path=/mnt/node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   testnet_node_alice:
     container_name: testnet_node_alice
-    image: cennznet/cennznet:develop-8a705e
+    image: cennznet/cennznet:develop-1d31b4
     command:
       - --chain=dev
       - --base-path=/mnt/node


### PR DESCRIPTION
For circle ci to test against the right node image, have updated docker-compose to point to update branch's commit version