### PR TITLE
Fix rxapi.queries.e2e.ts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,7 +75,6 @@ module.exports = {
         ],
         "import/no-extraneous-dependencies": "off",
         "import/order": "error",
-        "no-console": "error",
         "no-duplicate-imports": "error",
         // "no-magic-numbers": "error",
         "no-return-await": "error",

--- a/packages/api/src/Api.ts
+++ b/packages/api/src/Api.ts
@@ -15,18 +15,16 @@
 // import Types from '@cennznet/types/injects';
 import Types from '@cennznet/types/interfaces/injects';
 import { ApiPromise } from '@polkadot/api';
-import { ApiOptions as ApiOptionsBase, ApiTypes, SubmittableExtrinsics } from '@polkadot/api/types';
+import { ApiOptions as ApiOptionsBase, SubmittableExtrinsics } from '@polkadot/api/types';
 
 // import derives from './derives';
 // import rpc from './rpc';
 import staticMetadata from './staticMetadata';
 // import { ApiOptions, Derives, SubmittableExtrinsics } from './types';
 import { ApiOptions } from './types';
-import { mergeDeriveOptions } from './util/derives';
+// import { mergeDeriveOptions } from './util/derives';
 import { getProvider } from './util/getProvider';
 import { getTimeout } from './util/getTimeout';
-
-export const DEFAULT_TIMEOUT = 10000;
 
 export class Api extends ApiPromise {
   static async create(options: ApiOptions = {}): Promise<Api> {
@@ -75,7 +73,7 @@ export class Api extends ApiPromise {
   }
 }
 
-async function withTimeout(promise: Promise<Api>, timeoutMs: number = DEFAULT_TIMEOUT): Promise<Api> {
+async function withTimeout(promise: Promise<Api>, timeoutMs: number): Promise<Api> {
   if (timeoutMs === 0) {
     return promise;
   }

--- a/packages/api/src/ApiRx.ts
+++ b/packages/api/src/ApiRx.ts
@@ -17,11 +17,10 @@ import { mergeDeriveOptions } from '@cennznet/api/util/derives';
 import Types from '@cennznet/types/interfaces/injects';
 import { ApiRx as ApiRxBase } from '@polkadot/api';
 import { ApiOptions as ApiOptionsBase, SubmittableExtrinsics } from '@polkadot/api/types';
-import { fromEvent, Observable, race, throwError } from 'rxjs';
-import { switchMap, timeout } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { timeout } from 'rxjs/operators';
 
 // import rpc from '@cennznet/api/rpc';
-import { DEFAULT_TIMEOUT } from './Api';
 // import derives from './derives';
 import staticMetadata from './staticMetadata';
 // import { ApiOptions, Derives, SubmittableExtrinsics } from './types';
@@ -33,22 +32,19 @@ export class ApiRx extends ApiRxBase {
   static create(options: ApiOptions = {}): Observable<ApiRx> {
     const apiRx = new ApiRx(options);
 
-    const timeoutMs = getTimeout(options);
+    apiRx.on('error', (): void => {
+      console.error('An error occurred during connection establishment');
+    });
 
-    const rejectError = fromEvent((apiRx as any)._eventemitter, 'error').pipe(
-      switchMap(err => {
-        // Disconnect provider if API initialization fails
-        apiRx.disconnect();
+    apiRx.on('connected', (): void => {
+      console.info('API has been connected to the endpoint');
+    });
 
-        return throwError(new Error('Connection fail'));
-      })
-    );
-    const api$ = (apiRx.isReady as unknown) as Observable<ApiRx>;
-    // api$.subscribe(api => api.decorateCennznetExtrinsics());
+    apiRx.on('disconnected', (): void => {
+      console.info('API has been disconnected from the endpoint');
+    });
 
-    return timeoutMs === 0
-      ? race(api$, rejectError)
-      : race(api$.pipe(timeout(timeoutMs || DEFAULT_TIMEOUT)), rejectError);
+    return apiRx.isReady.pipe(timeout(getTimeout(options)));
   }
 
   get tx(): SubmittableExtrinsics<'rxjs'> {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -47,7 +47,6 @@ import {
   //   SubmittableResultSubscription,
   //   UnsubscribePromise,
 } from '@polkadot/api/types';
-// import { ProviderInterface } from '@polkadot/rpc-provider/types';
 // import { AccountId, Address, Hash } from '@polkadot/types/interfaces';
 // import { StorageEntry } from '@polkadot/types/primitive/StorageKey';
 // export * from '@polkadot/api/types';

--- a/packages/api/src/util/getTimeout.ts
+++ b/packages/api/src/util/getTimeout.ts
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ProviderInterface } from '@polkadot/rpc-provider/types';
-import { isFunction, isObject } from '@polkadot/util';
 import { ApiOptions } from '../types';
 
-export function getTimeout(options: ApiOptions | ProviderInterface = {}): number {
-  return isObject(options) && isFunction((options as ProviderInterface).send)
-    ? undefined
-    : (options as ApiOptions).timeout;
+const DEFAULT_TIMEOUT_MS: number = 10000;
+
+export function getTimeout(options: ApiOptions): number {
+  if (options.timeout) {
+    return options.timeout;
+  }
+  return DEFAULT_TIMEOUT_MS;
 }

--- a/packages/api/test/e2e/rxapi.create.e2e.ts
+++ b/packages/api/test/e2e/rxapi.create.e2e.ts
@@ -16,22 +16,14 @@ import {ApiRx} from '../../src/ApiRx';
 import initApiRx from '../../../../jest/initApiRx';
 
 describe('e2e rx api create', () => {
-  let apiRx;
-  let incorrectApiRx;
-
-  beforeAll(async () => {
-    const incorrectEndPoint = 'wss://rimu.centrality.cloud/';
-
-    apiRx = await initApiRx();
-    incorrectApiRx = await ApiRx.create({provider: incorrectEndPoint});
-  });
+  const incorrectEndPoint = 'wss://rimu.centrality.cloud/';
 
   afterAll(async done => {
-    apiRx = null;
-    incorrectApiRx = null;
     done();
   });
+
   it('Should create an Api instance with the timeout option', async done => {
+    const apiRx = await initApiRx();
     const api = await apiRx.toPromise();
 
     api.rpc.chain.getBlockHash().subscribe(hash => {
@@ -41,6 +33,7 @@ describe('e2e rx api create', () => {
   });
 
   it('Should create Api without timeout if timeout is 0', async done => {
+    const apiRx = await initApiRx();
     const api = await apiRx.toPromise();
     api.rpc.chain.getBlockHash().subscribe(hash => {
       expect(hash).toBeDefined();
@@ -49,12 +42,12 @@ describe('e2e rx api create', () => {
   });
 
   it('Should get error if the connection fails', async () => {
+    const incorrectApiRx = await ApiRx.create({provider: incorrectEndPoint});
     await expect(incorrectApiRx.toPromise()).rejects.toThrow(/Connection fail/);
   });
 
   it('Should get rejected if it is not resolved in a specific period of time', async () => {
-    incorrectApiRx = await ApiRx.create({timeout: -1});
-
+    const incorrectApiRx = await ApiRx.create({timeout: -1});
     await expect(incorrectApiRx.toPromise()).rejects.toThrow(/Timeout has occurred/);
   });
 });


### PR DESCRIPTION
Eventemitter was internal to ProviderInterface and programming towards the internal was wrong in the first place. Later Polkadot changed that internal private part and introduced "on" method for handling the error. 