### PR TITLE
Maintain the behaviour of ApiRx connection establishment

### DIFF
--- a/packages/api/src/ApiRx.ts
+++ b/packages/api/src/ApiRx.ts
@@ -32,10 +32,12 @@ export class ApiRx extends ApiRxBase {
 
     const observable: Observable<ApiRx> = new Observable(x => {
       apiRx.on('error', (): void => {
-        x.error(new Error('Connection fail'));
+        apiRx.disconnect().finally(() => {
+          x.error(new Error('Connection fail'));
+        });
       });
       apiRx.on('disconnected', (): void => {
-        x.error(new Error('Disconnected'));
+        console.info('API has been disconnected from the endpoint');
       });
       apiRx.on('connected', (): void => {
         console.info('API has been connected to the endpoint');


### PR DESCRIPTION
 Maintain the behaviour strictly as it used to be. During connection setup, there is an opportunity window for a disconnect to be useful between when a connection is made successfully and when the API is "ready".