### PR TITLE
support decoding of old block and current block on V37 chain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ jobs:
       - run:
           name: Run integration tests
           command: ./scripts/circleci/run_automation_test.sh -t integration
+          environment:
+          API_KEY: ${API_KEY}
   publish:
     docker:
       - image: circleci/node:10.16.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,6 @@ jobs:
       - run:
           name: Run integration tests
           command: ./scripts/circleci/run_automation_test.sh -t integration
-          environment:
-          API_KEY: ${API_KEY}
   publish:
     docker:
       - image: circleci/node:10.16.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
 
   api_test:
     container_name: api_test
+    environment:
+      - API_KEY=$API_KEY
     build:
       context: .
       dockerfile: api_test.Dockerfile

--- a/packages/api/src/Api.ts
+++ b/packages/api/src/Api.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Types from '@cennznet/types/interfaces/injects';
+import Types, { typesBundle } from '@cennznet/types/interfaces/injects';
 import { ApiPromise } from '@polkadot/api';
 import { ApiOptions as ApiOptionsBase, SubmittableExtrinsics } from '@polkadot/api/types';
 
@@ -67,7 +67,7 @@ export class Api extends ApiPromise {
     options.types = { ...options.types, ...Types };
     options.derives = mergeDeriveOptions(derives, options.derives);
     options.rpc = { ...rpc, ...options.rpc };
-
+    options.typesBundle = typesBundle;
     super(options as ApiOptionsBase);
   }
 }

--- a/packages/api/src/ApiRx.ts
+++ b/packages/api/src/ApiRx.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Types from '@cennznet/types/interfaces/injects';
+import Types, { typesBundle } from '@cennznet/types/interfaces/injects';
 import { ApiRx as ApiRxBase } from '@polkadot/api';
 import { ApiOptions as ApiOptionsBase, SubmittableExtrinsics } from '@polkadot/api/types';
 import { Observable } from 'rxjs';
@@ -68,6 +68,7 @@ export class ApiRx extends ApiRxBase {
     options.types = { ...options.types, ...Types };
     options.derives = mergeDeriveOptions(derives, options.derives);
     options.rpc = { ...rpc, ...options.rpc };
+    options.typesBundle = typesBundle;
 
     super(options as ApiOptionsBase);
   }

--- a/packages/types/src/interfaces/augment-types.ts
+++ b/packages/types/src/interfaces/augment-types.ts
@@ -50,6 +50,7 @@ import {
   VaultValue,
   WithdrawnPreKeyBundle,
 } from './sylo';
+import { doughnut } from './system';
 import { ChargeTransactionPayment, FeeExchange, FeeExchangeV1 } from './transactionPayment';
 import { BlockAttestations, IncludedBlocks, MoreAttestations } from '@polkadot/types/interfaces/attestations';
 import { RawAuraPreDigest } from '@polkadot/types/interfaces/aura';
@@ -2047,6 +2048,9 @@ declare module '@polkadot/types/types/registry' {
     Message: Message;
     'Option<Message>': Option<Message>;
     'Vec<Message>': Vec<Message>;
+    doughnut: doughnut;
+    'Option<doughnut>': Option<doughnut>;
+    'Vec<doughnut>': Vec<doughnut>;
     FeeExchangeV1: FeeExchangeV1;
     'Option<FeeExchangeV1>': Option<FeeExchangeV1>;
     'Vec<FeeExchangeV1>': Vec<FeeExchangeV1>;

--- a/packages/types/src/interfaces/extrinsic/index.ts
+++ b/packages/types/src/interfaces/extrinsic/index.ts
@@ -14,4 +14,5 @@
 
 export { default as CENNZnetExtrinsicPayloadV1 } from './v1/ExtrinsicPayload';
 export { default as CENNZnetExtrinsicSignatureV1 } from './v1/ExtrinsicSignature';
+export { default as CENNZnetExtrinsicSignatureV0 } from './v0/ExtrinsicSignatureV0';
 export { default as SignerPayload } from './SignerPayload';

--- a/packages/types/src/interfaces/extrinsic/types.ts
+++ b/packages/types/src/interfaces/extrinsic/types.ts
@@ -19,7 +19,9 @@ import {
   ExtrinsicPayloadValue as ExtrinsicPayloadValueBase,
   SignatureOptions as SignatureOptionsBase,
 } from '@polkadot/types/types';
+import { Option } from '@polkadot/types';
 import { ChargeTransactionPayment } from '../transactionPayment';
+import { doughnut } from '../types';
 
 export interface ExtrinsicPayloadValue extends ExtrinsicPayloadValueBase {
   transactionPayment?: AnyU8a | ChargeTransactionPayment;
@@ -27,4 +29,9 @@ export interface ExtrinsicPayloadValue extends ExtrinsicPayloadValueBase {
 
 export interface SignatureOptions extends SignatureOptionsBase {
   transactionPayment?: AnyU8a | ChargeTransactionPayment;
+}
+export interface ExtrinsicV0SignatureOptions extends SignatureOptionsBase {
+  doughnut?: Option<doughnut>;
+  transactionPayment?: ChargeTransactionPayment;
+  feeExchange?: any;
 }

--- a/packages/types/src/interfaces/extrinsic/v0/ExtrinsicPayloadV0.ts
+++ b/packages/types/src/interfaces/extrinsic/v0/ExtrinsicPayloadV0.ts
@@ -1,0 +1,145 @@
+// Copyright 2019-2020 Centrality Investments Limited & @polkadot/types authors & contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// tslint:disable member-ordering no-magic-numbers
+import { Bytes, Compact, Raw, Struct, u32 } from '@polkadot/types';
+import { Balance, ExtrinsicEra, Hash } from '@polkadot/types/interfaces';
+import { sign } from '@polkadot/types/extrinsic/util';
+import { AnyNumber, AnyU8a, IExtrinsicEra, IKeyringPair, IMethod, Registry } from '@polkadot/types/types';
+import Option from '@polkadot/types/codec/Option';
+import { ChargeTransactionPayment, doughnut, Index } from '../../types';
+
+export interface ExtrinsicPayloadValueV0 {
+  blockHash: AnyU8a;
+  doughnut: Option<Raw>;
+  era: AnyU8a | IExtrinsicEra;
+  genesisHash: AnyU8a;
+  method: AnyU8a | IMethod;
+  nonce: AnyNumber;
+  specVersion: AnyNumber;
+  tip: AnyNumber;
+  transactionPayment?: AnyU8a | ChargeTransactionPayment;
+}
+
+// The base of an extrinsic payload
+export const BasePayloadV0: Record<string, any> = {
+  method: 'Bytes',
+  doughnut: 'Option<Doughnut>',
+  era: 'ExtrinsicEra',
+  nonce: 'Compact<Index>',
+  transactionPayment: 'ChargeTransactionPayment',
+};
+
+// These fields are signed here as part of the extrinsic signature but are NOT encoded in
+// the final extrinsic payload itself.
+// The CENNZnet node will populate these fields from on-chain data and check the signature compares
+// hence 'implicit'
+export const PayloadImplicitAddonsV0: Record<string, any> = {
+  specVersion: 'u32',
+  genesisHash: 'Hash',
+  blockHash: 'Hash',
+};
+
+// The full definition for the extrinsic payload.
+// It will be encoded (+ hashed if len > 256) and then signed to make the extrinsic signature
+export const FullPayloadV0: Record<string, any> = {
+  ...BasePayloadV0,
+  ...PayloadImplicitAddonsV0,
+};
+/**
+ * @name ExtrinsicPayloadV0
+ * @description
+ * A signing payload for an [[Extrinsic]]. For the final encoding, it is variable length based
+ * on the contents included
+ *
+ *   1-8 bytes: The Transaction Compact<Index/Nonce> as provided in the transaction itself.
+ *   2+ bytes: The Function Descriptor as provided in the transaction itself.
+ *   1/2 bytes: The Transaction Era as provided in the transaction itself.
+ *   32 bytes: The hash of the authoring block implied by the Transaction Era and the current block.
+ */
+export default class ExtrinsicPayloadV0 extends Struct {
+  constructor(registry: Registry, value?: ExtrinsicPayloadValueV0 | Uint8Array | string) {
+    super(registry, FullPayloadV0, value);
+  }
+
+  /**
+   * @description The block [[Hash]] the signature applies to (mortal/immortal)
+   */
+  get blockHash(): Hash {
+    return this.get('blockHash') as Hash;
+  }
+
+  /**
+   * @description The genesis [[Hash]] the signature applies to (mortal/immortal)
+   */
+  get genesisHash(): Hash {
+    return this.get('genesisHash') as Hash;
+  }
+
+  /**
+   * @description The [[Bytes]] contained in the payload
+   */
+  get method(): Bytes {
+    return this.get('method') as Bytes;
+  }
+
+  /**
+   * @description The [[ExtrinsicEra]]
+   */
+  get era(): ExtrinsicEra {
+    return this.get('era') as ExtrinsicEra;
+  }
+
+  /**
+   * @description The [[Index]]
+   */
+  get nonce(): Compact<Index> {
+    return this.get('nonce') as Compact<Index>;
+  }
+
+  /**
+   * @description The specVersion for this signature
+   */
+  get specVersion(): u32 {
+    return this.get('specVersion') as u32;
+  }
+
+  /**
+   * @description tip (here for compatibility with [[IExtrinsic]] definition)
+   */
+  get tip(): Compact<Balance> {
+    return this.transactionPayment.tip as Compact<Balance>;
+  }
+
+  /**
+   * @description The transaction fee metadata e.g tip, fee exchange
+   */
+  get transactionPayment(): ChargeTransactionPayment {
+    return this.get('transactionPayment') as ChargeTransactionPayment;
+  }
+
+  /**
+   * @description The [[Doughnut]]
+   */
+  get doughnut(): Option<doughnut> {
+    return this.get('doughnut') as Option<doughnut>;
+  }
+
+  /**
+   * @description Sign the payload with the keypair
+   */
+  sign(signerPair: IKeyringPair): Uint8Array {
+    return sign(this.registry, signerPair, this.toU8a({ method: true }), { withType: true });
+  }
+}

--- a/packages/types/src/interfaces/extrinsic/v0/ExtrinsicSignatureV0.ts
+++ b/packages/types/src/interfaces/extrinsic/v0/ExtrinsicSignatureV0.ts
@@ -1,0 +1,279 @@
+// Copyright 2019-2020 Centrality Investments Limited & @polkadot/types authors & contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// tslint:disable member-ordering no-magic-numbers
+import { Compact, createType, Struct } from '@polkadot/types';
+import Option from '@polkadot/types/codec/Option';
+import {
+  Address,
+  Balance,
+  Call,
+  Index,
+  EcdsaSignature,
+  Ed25519Signature,
+  ExtrinsicEra,
+  MultiSignature,
+  Sr25519Signature,
+} from '@polkadot/types/interfaces';
+import { EMPTY_U8A, IMMORTAL_ERA } from '@polkadot/types/extrinsic/constants';
+import { IExtrinsicSignature, IKeyringPair, Registry } from '@polkadot/types/types';
+import { u8aConcat } from '@polkadot/util';
+import { ExtrinsicSignatureOptions } from '@polkadot/types/extrinsic/types';
+import { ExtrinsicV0SignatureOptions } from '../types';
+import { ChargeTransactionPayment, doughnut } from '../../types';
+import ExtrinsicPayloadV0, { ExtrinsicPayloadValueV0 } from './ExtrinsicPayloadV0';
+
+/**
+ * @name ExtrinsicSignature
+ * @description
+ * A container for the [[Signature]] associated with a specific [[Extrinsic]]
+ */
+export default class ExtrinsicSignatureV0 extends Struct implements IExtrinsicSignature {
+  constructor(
+    registry: Registry,
+    value: ExtrinsicSignatureV0 | Uint8Array | undefined,
+    { isSigned }: ExtrinsicSignatureOptions = {}
+  ) {
+    super(
+      registry,
+      {
+        signer: 'Address',
+        signature: 'MultiSignature',
+        doughnut: 'Option<doughnut>',
+        era: 'ExtrinsicEra',
+        nonce: 'Compact<Index>',
+        transactionPayment: 'ChargeTransactionPayment',
+      },
+      ExtrinsicSignatureV0.decodeExtrinsicSignature(value, isSigned)
+    );
+  }
+
+  static decodeExtrinsicSignature(
+    value: ExtrinsicSignatureV0 | Uint8Array | undefined,
+    isSigned = false
+  ): ExtrinsicSignatureV0 | Uint8Array {
+    if (!value) {
+      return EMPTY_U8A;
+    } else if (value instanceof ExtrinsicSignatureV0) {
+      return value;
+    }
+    return isSigned ? value : EMPTY_U8A;
+  }
+
+  /**
+   * @description The length of the value when encoded as a Uint8Array
+   */
+  get encodedLength(): number {
+    return this.isSigned ? super.encodedLength : 0;
+  }
+
+  /**
+   * @description `true` if the signature is valid
+   */
+  get isSigned(): boolean {
+    return !this.signature.isEmpty;
+  }
+
+  /**
+   * @description The [[ExtrinsicEra]] (mortal or immortal) this signature applies to
+   */
+  get era(): ExtrinsicEra {
+    return this.get('era') as ExtrinsicEra;
+  }
+
+  /**
+   * @description The [[Index]] for the signature
+   */
+  get nonce(): Compact<Index> {
+    return this.get('nonce') as Compact<Index>;
+  }
+
+  /**
+   * @description The [[Doughnut]]
+   */
+  get doughnut(): Option<doughnut> {
+    return this.get('doughnut') as Option<doughnut>;
+  }
+
+  /**
+   * @description The actuall [[Signature]] hash
+   */
+  //  get signature(): EcdsaSignature | Ed25519Signature | Sr25519Signature {
+  get signature(): EcdsaSignature | Ed25519Signature | Sr25519Signature {
+    return this.multiSignature.value as Sr25519Signature;
+  }
+
+  /**
+   * @description The raw [[MultiSignature]]
+   */
+  get multiSignature(): MultiSignature {
+    return this.get('signature') as MultiSignature;
+  }
+  /**
+   * @description The [[Address]] that signed
+   */
+  get signer(): Address {
+    return this.get('signer') as Address;
+  }
+
+  /**
+   * @description tip (here for compatibility with [[IExtrinsic]] definition)
+   */
+  get tip(): Compact<Balance> {
+    return this.transactionPayment.tip as Compact<Balance>;
+  }
+
+  /**
+   * @description The transaction fee metadata e.g tip, fee exchange
+   */
+  get transactionPayment(): ChargeTransactionPayment {
+    return this.get('transactionPayment') as ChargeTransactionPayment;
+  }
+
+  private injectSignature(
+    signer: Address,
+    signature: MultiSignature,
+    { doughnut, era, nonce, transactionPayment }: ExtrinsicPayloadV0
+  ): IExtrinsicSignature {
+    this.set('doughnut', doughnut);
+    this.set('era', era);
+    this.set('nonce', nonce);
+    this.set('signer', signer);
+    this.set('signature', signature);
+    this.set('transactionPayment', transactionPayment);
+
+    return this;
+  }
+
+  /**
+   * @description Adds a raw signature
+   */
+  addSignature(
+    signer: Address | Uint8Array | string,
+    signature: Uint8Array | string,
+    payload: ExtrinsicPayloadValueV0 | Uint8Array | string
+  ): IExtrinsicSignature {
+    return this.injectSignature(
+      createType(this.registry, 'Address', signer),
+      createType(this.registry, 'MultiSignature', signature),
+      new ExtrinsicPayloadV0(this.registry, payload)
+    );
+  }
+
+  /**
+   * @description Creates a payload from the supplied options
+   */
+  createPayload(
+    method: Call,
+    {
+      blockHash,
+      era,
+      genesisHash,
+      nonce,
+      doughnut,
+      runtimeVersion: { specVersion },
+      transactionPayment,
+    }: ExtrinsicV0SignatureOptions
+  ): ExtrinsicPayloadV0 {
+    return new ExtrinsicPayloadV0(this.registry, {
+      blockHash,
+      doughnut: doughnut || createType(this.registry, 'Option<doughnut>'),
+      era: era || IMMORTAL_ERA,
+      genesisHash,
+      method: method.toHex(),
+      nonce,
+      specVersion,
+      // [[tip]] is now set inside [[transactionPayment]]
+      // This doesn't do anything, just signalling our intention not to use it.
+      tip: null,
+      transactionPayment: transactionPayment || createType(this.registry, 'ChargeTransactionPayment'),
+    });
+  }
+
+  /**
+   * @description Generate a payload and pplies the signature from a keypair
+   */
+  sign(
+    method: Call,
+    account: IKeyringPair,
+    {
+      blockHash,
+      era,
+      genesisHash,
+      nonce,
+      doughnut,
+      runtimeVersion: { specVersion },
+      tip,
+      transactionPayment,
+    }: ExtrinsicV0SignatureOptions
+  ): IExtrinsicSignature {
+    const signer = createType(this.registry, 'Address', account.publicKey);
+    const payload = this.createPayload(method, {
+      blockHash,
+      era,
+      genesisHash,
+      nonce,
+      doughnut,
+      runtimeVersion: { specVersion },
+      transactionPayment,
+    } as ExtrinsicV0SignatureOptions);
+    const signature = createType(this.registry, 'MultiSignature', payload.sign(account));
+    return this.injectSignature(signer, signature, payload);
+  }
+
+  /**
+   * @description Generate a payload and applies a fake signature
+   */
+  signFake(
+    method: Call,
+    address: Address | Uint8Array | string,
+    {
+      blockHash,
+      era,
+      genesisHash,
+      nonce,
+      doughnut,
+      runtimeVersion: { specVersion },
+      tip,
+      transactionPayment,
+    }: ExtrinsicV0SignatureOptions
+  ): IExtrinsicSignature {
+    const signer = createType(this.registry, 'Address', address);
+    const payload = this.createPayload(method, {
+      blockHash,
+      era,
+      genesisHash,
+      nonce,
+      doughnut,
+      runtimeVersion: { specVersion },
+      tip,
+      transactionPayment,
+    } as ExtrinsicV0SignatureOptions);
+    const signature = createType(
+      this.registry,
+      'MultiSignature',
+      u8aConcat(new Uint8Array([1]), new Uint8Array(64).fill(0x42))
+    );
+
+    return this.injectSignature(signer, signature, payload);
+  }
+
+  /**
+   * @description Encodes the value as a Uint8Array as per the SCALE specifications
+   * @param isBare true when the value has none of the type-specific prefixes (internal)
+   */
+  toU8a(isBare?: boolean): Uint8Array {
+    return this.isSigned ? super.toU8a(isBare) : EMPTY_U8A;
+  }
+}

--- a/packages/types/src/interfaces/injects.ts
+++ b/packages/types/src/interfaces/injects.ts
@@ -15,8 +15,10 @@
 // CENNZnet types for injection into a polkadot API session
 
 import VecAny from '@polkadot/types/codec/VecAny';
-import { CENNZnetExtrinsicSignatureV1, SignerPayload } from './extrinsic';
+import { OverrideBundleType } from '@polkadot/types/types/registry';
+import { CENNZnetExtrinsicSignatureV1, CENNZnetExtrinsicSignatureV0, SignerPayload } from './extrinsic';
 import * as definitions from './definitions';
+import * as syloTypes from './sylo/v0/index';
 
 const _types = {
   ...definitions,
@@ -24,7 +26,6 @@ const _types = {
   // This funny format, makes it compatible with the structure from generated definitions
   other: {
     types: {
-      ExtrinsicSignatureV4: CENNZnetExtrinsicSignatureV1,
       VecDeque: VecAny,
       SignerPayload,
     },
@@ -33,3 +34,25 @@ const _types = {
 
 // Unwind the nested type definitions into a flat map
 export default Object.values(_types).reduce((res, { types }): object => ({ ...res, ...types }), {});
+
+export const typesBundle: OverrideBundleType = {
+  spec: {
+    cennznet: {
+      types: [
+        {
+          minmax: [0, 36],
+          types: {
+            ...syloTypes,
+            ExtrinsicSignatureV4: CENNZnetExtrinsicSignatureV0,
+          },
+        },
+        {
+          minmax: [37, undefined],
+          types: {
+            ExtrinsicSignatureV4: CENNZnetExtrinsicSignatureV1,
+          },
+        },
+      ],
+    },
+  },
+};

--- a/packages/types/src/interfaces/sylo/v0/index.ts
+++ b/packages/types/src/interfaces/sylo/v0/index.ts
@@ -1,0 +1,129 @@
+// Copyright 2019 Centrality Investments Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ClassOf, Enum, Struct, Text, Tuple, TypeRegistry, Vec } from '@polkadot/types';
+import { Registry } from '@polkadot/types/types';
+import { u8aToHex } from '@polkadot/util';
+
+const GROUP_JSON_MAP = new Map([['groupId', 'group_id']]);
+
+export class Group extends Struct {
+  constructor(registry: Registry, value) {
+    super(
+      registry,
+      {
+        groupId: 'H256',
+        members: Vec.with(Member),
+        invites: Vec.with(PendingInvite),
+        meta: Meta,
+      },
+      value,
+      GROUP_JSON_MAP
+    );
+  }
+}
+
+const MEMBER_JSON_MAP = new Map([['userId', 'user_id']]);
+
+export class Member extends Struct {
+  constructor(registry: Registry, value) {
+    super(registry, { userId: 'AccountId', roles: Vec.with(MemberRoles), meta: Meta }, value, MEMBER_JSON_MAP);
+  }
+
+  toJSON() {
+    return {
+      user_id: u8aToHex(this.get('userId').toU8a(), -1, false),
+      roles: this.get('roles').toJSON(),
+      meta: this.get('meta').toJSON(),
+    };
+  }
+}
+
+export class MemberRoles extends Enum.with(['AdminRole', 'MemberRole']) {}
+
+export class Meta extends Vec.with(Tuple.with([Text, Text])) {}
+
+const INVITE_JSON_MAP = new Map([
+  ['peerId', 'peer_id'],
+  ['inviteData', 'invite_data'],
+  ['inviteKey', 'invite_key'],
+]);
+
+export class Invite extends Struct {
+  constructor(registry: Registry, value) {
+    super(
+      registry,
+      {
+        peerId: 'AccountId',
+        inviteData: 'Bytes',
+        inviteKey: 'H256',
+        meta: Meta,
+        roles: Vec.with(MemberRoles),
+      },
+      value,
+      INVITE_JSON_MAP
+    );
+  }
+}
+
+const PENDING_INVITE_JSON_MAP = new Map([['inviteKey', 'invite_key']]);
+
+export class PendingInvite extends Struct {
+  constructor(registry: Registry, value) {
+    super(registry, { inviteKey: 'H256', meta: Meta, roles: Vec.with(MemberRoles) }, value, PENDING_INVITE_JSON_MAP);
+  }
+
+  toJSON() {
+    return {
+      invite_key: u8aToHex(this.get('inviteKey').toU8a(), -1, false),
+      meta: this.get('meta').toJSON(),
+      roles: this.get('roles').toJSON(),
+    };
+  }
+}
+
+export class AcceptPayload extends Struct {
+  constructor(registry: Registry, value) {
+    super(registry, { account_id: 'AccountId' }, value);
+  }
+}
+const registry = new TypeRegistry();
+export class DeviceId extends ClassOf(registry, 'u32') {}
+
+export class PreKeyBundle extends ClassOf(registry, 'Bytes') {
+  constructor(values) {
+    super(values);
+  }
+}
+
+// Response enum constructors
+class DeviceIdResponse extends DeviceId {}
+class WithdrawnPreKeyBundle extends Tuple.with(['AccountId', 'u32', 'Bytes']) {
+  constructor(values) {
+    super(values);
+  }
+
+  toJSON() {
+    const values = this.toArray();
+    const [accountId, deviceId, pkb] = values;
+    return [u8aToHex(accountId.toU8a(), -1, false), deviceId.toJSON(), u8aToHex(pkb.toU8a(true))];
+  }
+}
+class PreKeyBundlesResponse extends Vec.with(WithdrawnPreKeyBundle) {}
+
+export class Response extends Enum.with({ DeviceIdResponse, PreKeyBundlesResponse }) {}
+
+export class VaultKey extends ClassOf(registry, 'Bytes') {}
+
+export class VaultValue extends ClassOf(registry, 'Bytes') {}

--- a/packages/types/src/interfaces/system/definitions.ts
+++ b/packages/types/src/interfaces/system/definitions.ts
@@ -3,5 +3,6 @@ export default {
   types: {
     Address: 'AccountId',
     Index: 'u64',
+    doughnut: 'Raw',
   },
 };

--- a/packages/types/src/interfaces/system/types.ts
+++ b/packages/types/src/interfaces/system/types.ts
@@ -3,6 +3,7 @@
 
 import { u64 } from '@polkadot/types/primitive';
 import { AccountId } from '@polkadot/types/interfaces/runtime';
+import { Raw } from '@polkadot/types';
 
 /** @name Address */
 export interface Address extends AccountId {}
@@ -11,3 +12,5 @@ export interface Address extends AccountId {}
 export interface Index extends u64 {}
 
 export type PHANTOM_SYSTEM = 'system';
+
+export interface doughnut extends Raw {}


### PR DESCRIPTION
This PR is to address the issue decoding the blocks running on Azalea which supports old types (Extrinsic Signature). The fix was inspired by the way it was handled in https://github.com/polkadot-js/api/issues/2723
With typesBundle we can now let the API know which type definition to use for what version
I have tested it for some blocks on Azalea which had GA as well as Sylo extrinsic.. It decodes well.. Also tried to use send an extrinsic on v37 and tried to see if the block decodes well..