### PR TITLE
Chore/patch balance derive

### DIFF
--- a/packages/api/src/derives/attestation/attestation.e2e.ts
+++ b/packages/api/src/derives/attestation/attestation.e2e.ts
@@ -46,9 +46,10 @@ afterAll(async () => {
 describe('Attestation APIs', () => {
   describe('Set Claims', () => {
     it('should create a claim', async done => {
+      const nonce = await api.rpc.system.accountNextIndex(issuer.address);
       await api.tx.attestation
         .setClaim(holder.address, topic, attestationValue.toHex())
-        .signAndSend(issuer, async ({ events, status }) => {
+        .signAndSend(issuer, { nonce }, async ({ events, status }) => {
           if (status.isInBlock && events !== undefined) {
             for (const {
               event: { method, data },
@@ -68,10 +69,11 @@ describe('Attestation APIs', () => {
     });
 
     it('should create a claim with a u8a', async done => {
+      const nonce = await api.rpc.system.accountNextIndex(issuer.address);
       const otherTopic = api.registry.createType('AttestationTopic', '0x72616e646f6d546f706963'); // hex for randomTopic
       await api.tx.attestation
         .setClaim(holder.address, otherTopic, attestationValue.toU8a())
-        .signAndSend(issuer, async ({ events, status }) => {
+        .signAndSend(issuer, { nonce }, async ({ events, status }) => {
           if (status.isInBlock && events !== undefined) {
             for (const {
               event: { method, data },
@@ -102,9 +104,10 @@ describe('Attestation APIs', () => {
 
   describe('Create Multiple Claims', () => {
     it('should create a claim with issuer 1 and topic 1', async done => {
+      const nonce = await api.rpc.system.accountNextIndex(issuer.address);
       await api.tx.attestation
         .setClaim(holder.address, topic, attestationValue.toHex())
-        .signAndSend(issuer, async ({ events, status }) => {
+        .signAndSend(issuer, { nonce }, async ({ events, status }) => {
           if (status.isInBlock && events !== undefined) {
             for (const {
               event: { method, data },
@@ -124,9 +127,10 @@ describe('Attestation APIs', () => {
     });
 
     it('should create a claim with issuer 1 and topic 2', async done => {
+      const nonce = await api.rpc.system.accountNextIndex(issuer.address);
       await api.tx.attestation
         .setClaim(holder.address, topic2, attestationValue2.toHex())
-        .signAndSend(issuer, async ({ events, status }) => {
+        .signAndSend(issuer, { nonce }, async ({ events, status }) => {
           if (status.isInBlock && events !== undefined) {
             for (const {
               event: { method, data },
@@ -146,9 +150,10 @@ describe('Attestation APIs', () => {
     });
 
     it('should create a claim with issuer 2 and topic 1', async done => {
+      const nonce = await api.rpc.system.accountNextIndex(issuer2.address);
       await api.tx.attestation
         .setClaim(holder.address, topic, attestationValue.toHex())
-        .signAndSend(issuer2, async ({ events, status }) => {
+        .signAndSend(issuer2, { nonce }, async ({ events, status }) => {
           if (status.isInBlock && events !== undefined) {
             for (const {
               event: { method, data },
@@ -168,9 +173,10 @@ describe('Attestation APIs', () => {
     });
 
     it('should create a claim with issuer 2 and topic 2', async done => {
+      const nonce = await api.rpc.system.accountNextIndex(issuer2.address);
       await api.tx.attestation
         .setClaim(holder.address, topic2, attestationValue2.toHex())
-        .signAndSend(issuer2, async ({ events, status }) => {
+        .signAndSend(issuer2, { nonce }, async ({ events, status }) => {
           if (status.isInBlock && events !== undefined) {
             for (const {
               event: { method, data },
@@ -216,9 +222,10 @@ describe('Attestation APIs', () => {
 
   describe('Remove Claims', () => {
     it('should create a claim', async done => {
+      const nonce = await api.rpc.system.accountNextIndex(issuer.address);
       await api.tx.attestation
         .setClaim(holder.address, topic, attestationValue.toHex())
-        .signAndSend(issuer, async ({ events, status }) => {
+        .signAndSend(issuer, { nonce }, async ({ events, status }) => {
           if (status.isInBlock && events !== undefined) {
             for (const {
               event: { method, data },
@@ -238,23 +245,26 @@ describe('Attestation APIs', () => {
     });
 
     it('should remove a claim', async done => {
+      const nonce = await api.rpc.system.accountNextIndex(issuer.address);
       // Expect holders to match
-      await api.tx.attestation.removeClaim(holder.address, topic).signAndSend(issuer, async ({ events, status }) => {
-        if (status.isInBlock && events !== undefined) {
-          for (const {
-            event: { method, data },
-          } of events) {
-            if (method === 'ClaimRemoved') {
-              expect(data[0].toString()).toBe(holder.address);
-              // Expect issuers to match
-              expect(data[1].toString()).toBe(issuer.address);
-              // expect topic to match
-              expect(data[2].toHex()).toEqual(topic.toHex());
-              done();
+      await api.tx.attestation
+        .removeClaim(holder.address, topic)
+        .signAndSend(issuer, { nonce }, async ({ events, status }) => {
+          if (status.isInBlock && events !== undefined) {
+            for (const {
+              event: { method, data },
+            } of events) {
+              if (method === 'ClaimRemoved') {
+                expect(data[0].toString()).toBe(holder.address);
+                // Expect issuers to match
+                expect(data[1].toString()).toBe(issuer.address);
+                // expect topic to match
+                expect(data[2].toHex()).toEqual(topic.toHex());
+                done();
+              }
             }
           }
-        }
-      });
+        });
     });
   });
 });

--- a/packages/api/src/derives/attestation/attestationRx.e2e.ts
+++ b/packages/api/src/derives/attestation/attestationRx.e2e.ts
@@ -50,11 +50,11 @@ afterAll(async () => {
 
 describe('AttestationRx APIs', () => {
   describe('Set Claims', () => {
-    it('should create a claim', done => {
+    it('should create a claim', async done => {
       const claim = api.tx.attestation.setClaim(holder.address, topic, attestationValue.toHex());
-
+      const nonce = await api.rpc.system.accountNextIndex(issuer.address).toPromise();
       claim
-        .signAndSend(issuer)
+        .signAndSend(issuer, { nonce })
         .pipe(
           filter(({ events, status }) => {
             return status.isInBlock && events !== undefined;
@@ -93,11 +93,11 @@ describe('AttestationRx APIs', () => {
   });
 
   describe('Create Multiple Claims', () => {
-    it('should create a claim with issuer 1 and topic 1', done => {
+    it('should create a claim with issuer 1 and topic 1', async done => {
       const claim = api.tx.attestation.setClaim(holder.address, topic, attestationValue.toHex());
-
+      const nonce = await api.rpc.system.accountNextIndex(issuer.address).toPromise();
       claim
-        .signAndSend(issuer)
+        .signAndSend(issuer, { nonce })
         .pipe(
           filter(({ events, status }) => {
             return status.isInBlock && events !== undefined;
@@ -120,11 +120,11 @@ describe('AttestationRx APIs', () => {
         });
     });
 
-    it('should create a claim with issuer 1 and topic 2', done => {
+    it('should create a claim with issuer 1 and topic 2', async done => {
       const claim = api.tx.attestation.setClaim(holder.address, topic2, attestationValue2.toHex());
-
+      const nonce = await api.rpc.system.accountNextIndex(issuer.address).toPromise();
       claim
-        .signAndSend(issuer)
+        .signAndSend(issuer, { nonce })
         .pipe(
           filter(({ events, status }) => {
             return status.isInBlock && events !== undefined;
@@ -147,11 +147,11 @@ describe('AttestationRx APIs', () => {
         });
     });
 
-    it('should create a claim with issuer 2 and topic 1', done => {
+    it('should create a claim with issuer 2 and topic 1', async done => {
       const claim = api.tx.attestation.setClaim(holder.address, topic, attestationValue.toHex());
-
+      const nonce = await api.rpc.system.accountNextIndex(issuer2.address).toPromise();
       claim
-        .signAndSend(issuer2)
+        .signAndSend(issuer2, { nonce })
         .pipe(
           filter(({ events, status }) => {
             return status.isInBlock && events !== undefined;
@@ -174,11 +174,12 @@ describe('AttestationRx APIs', () => {
         });
     });
 
-    it('should create a claim with issuer 2 and topic 2', done => {
+    it('should create a claim with issuer 2 and topic 2', async done => {
       const claim = api.tx.attestation.setClaim(holder.address, topic2, attestationValue2.toHex());
+      const nonce = await api.rpc.system.accountNextIndex(issuer2.address).toPromise();
 
       claim
-        .signAndSend(issuer2)
+        .signAndSend(issuer2, { nonce })
         .pipe(
           filter(({ events, status }) => {
             return status.isInBlock && events !== undefined;
@@ -231,12 +232,12 @@ describe('AttestationRx APIs', () => {
   });
 
   describe('Remove Claims', () => {
-    it('should remove a claim', done => {
+    it('should remove a claim', async done => {
       const claim = api.tx.attestation.removeClaim(holder.address, topic);
-
+      const nonce = await api.rpc.system.accountNextIndex(issuer.address).toPromise();
       // Expect holders to match
       claim
-        .signAndSend(issuer)
+        .signAndSend(issuer, { nonce })
         .pipe(
           filter(({ events, status }) => {
             return status.isInBlock && events !== undefined;

--- a/packages/api/src/derives/balances.ts
+++ b/packages/api/src/derives/balances.ts
@@ -1,0 +1,22 @@
+// Copyright 2020 Centrality Investments Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Adding this file to support extrinsic via rv36
+import { ApiInterfaceRx } from '@polkadot/api/types';
+import { Observable, of } from 'rxjs';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function account(instanceId: string, api: ApiInterfaceRx) {
+  return (address: string): Observable<any> => of(address);
+}

--- a/packages/api/src/derives/cennzx/cennzxTrade.e2e.ts
+++ b/packages/api/src/derives/cennzx/cennzxTrade.e2e.ts
@@ -146,10 +146,11 @@ describe('Cennzx Operations', () => {
       const expectedPrice = await api.rpc.cennzx.buyPrice(assetToBuy, amountBought, assetToSell);
       const buffer = 100;
       const maxAmountSold = expectedPrice.addn(buffer); // Maximum of assetA willing to pay for the exchange
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       // sell assetA to buy coreAsset
       await api.tx.cennzx
         .buyAsset(recipient, assetToSell, assetToBuy, amountBought, maxAmountSold)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetBought') {
@@ -170,10 +171,11 @@ describe('Cennzx Operations', () => {
       const expectedPrice = await api.rpc.cennzx.buyPrice(assetToBuy, amountBought, assetToSell);
       const buffer = 100;
       const maxAmountSold = expectedPrice.addn(buffer); // Maximum of coreAsset willing to pay for the exchange
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       // sell assetA to buy coreAsset
       await api.tx.cennzx
         .buyAsset(recipient, assetToSell, assetToBuy, amountBought, maxAmountSold)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetBought') {
@@ -194,9 +196,10 @@ describe('Cennzx Operations', () => {
       const sellAmount = 50;
       const expectedAssetPrice = await api.rpc.cennzx.sellPrice(assetToSell, sellAmount, assetToBuy);
       const minSale = 1;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       await api.tx.cennzx
         .sellAsset(recipient, assetToSell, assetToBuy, sellAmount, minSale)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetSold') {
@@ -217,10 +220,11 @@ describe('Cennzx Operations', () => {
       const sellAmount = 50;
       const expectedPrice = await api.rpc.cennzx.sellPrice(assetToSell, sellAmount, assetToBuy);
       const minSale = 1;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       const recipientBalaneBefore = await api.query.genericAsset.freeBalance(assetToBuy, recipient);
       await api.tx.cennzx
         .sellAsset(recipient, assetToSell, assetToBuy, sellAmount, minSale)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetSold') {
@@ -243,11 +247,12 @@ describe('Cennzx Operations', () => {
       const assetToSell = assetA;
       const assetToBuy = coreAssetId;
       const sellAmount = 50;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       const expectedCorePrice = await api.rpc.cennzx.sellPrice(assetToSell, sellAmount, assetToBuy);
       const minSale = 1;
       await api.tx.cennzx
         .sellAsset(recipient, assetToSell, assetToBuy, sellAmount, minSale)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetSold') {
@@ -266,12 +271,13 @@ describe('Cennzx Operations', () => {
       const assetToSell = assetA;
       const assetToBuy = coreAssetId;
       const sellAmount = 50;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       const expectedPrice = await api.rpc.cennzx.sellPrice(assetToSell, sellAmount, assetToBuy);
       const recipientBalaneBefore = await api.query.genericAsset.freeBalance(assetToBuy, recipient);
       const minSale = 1;
       await api.tx.cennzx
         .sellAsset(recipient, assetToSell, assetToBuy, sellAmount, minSale)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetSold') {
@@ -297,10 +303,11 @@ describe('Cennzx Operations', () => {
       const expectedAssetPrice = await api.rpc.cennzx.buyPrice(assetToBuy, amountBought, assetToSell);
       const recipientBalaneBefore = await api.query.genericAsset.freeBalance(assetToBuy, recipient);
       const buffer = 100;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       const maxAmountSold = expectedAssetPrice.addn(buffer); // Maximum of coreAsset willing to pay for the exchange
       await api.tx.cennzx
         .buyAsset(recipient, assetToSell, assetToBuy, amountBought, maxAmountSold)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetBought') {
@@ -326,10 +333,11 @@ describe('Cennzx Operations', () => {
       const expectedPrice = await api.rpc.cennzx.buyPrice(assetToBuy, amountBought, assetToSell);
       const recipientBalaneBefore = await api.query.genericAsset.freeBalance(assetToBuy, recipient);
       const buffer = 100;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       const maxAmountSold = expectedPrice.addn(buffer); // Maximum willing to pay for the exchange
       await api.tx.cennzx
         .buyAsset(recipient, assetToSell, assetToBuy, amountBought, maxAmountSold)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetBought') {
@@ -354,10 +362,11 @@ describe('Cennzx Operations', () => {
       const amountBought = 50;
       const expectedPrice = await api.rpc.cennzx.buyPrice(assetToBuy, amountBought, assetToSell);
       const buffer = 100;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       const maxAmountSold = expectedPrice.addn(buffer); // Maximum willing to pay for the exchange
       await api.tx.cennzx
         .buyAsset(recipient, assetToSell, assetToBuy, amountBought, maxAmountSold)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetBought') {
@@ -378,11 +387,12 @@ describe('Cennzx Operations', () => {
       const amountBought = 50;
       const expectedPrice = await api.rpc.cennzx.buyPrice(assetToBuy, amountBought, assetToSell);
       const buffer = 100;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       const maxAmountSold = expectedPrice.addn(buffer); // Maximum willing to pay for the exchange
       const recipientBalaneBefore = await api.query.genericAsset.freeBalance(assetToBuy, recipient);
       await api.tx.cennzx
         .buyAsset(recipient, assetToSell, assetToBuy, amountBought, maxAmountSold)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetBought') {
@@ -407,9 +417,10 @@ describe('Cennzx Operations', () => {
       const sellAmount = 50;
       const expectedPrice = await api.rpc.cennzx.sellPrice(assetToSell, sellAmount, assetToBuy);
       const minSale = 1;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       await api.tx.cennzx
         .sellAsset(recipient, assetToSell, assetToBuy, sellAmount, minSale)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetSold') {
@@ -430,10 +441,11 @@ describe('Cennzx Operations', () => {
       const sellAmount = 50;
       const expectedPrice = await api.rpc.cennzx.sellPrice(assetToSell, sellAmount, assetToBuy);
       const minSale = 1;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       const recipientBalaneBefore = await api.query.genericAsset.freeBalance(assetToBuy, recipient);
       await api.tx.cennzx
         .sellAsset(recipient, assetToSell, assetToBuy, sellAmount, minSale)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'AssetSold') {
@@ -469,9 +481,10 @@ describe('Cennzx Operations', () => {
       const { coreAmount, assetAmount } = await api.derive.cennzx.assetToWithdraw(assetA, removeLiquidity);
       const minAssetWithdraw = 1;
       const minCoreWithdraw = 1;
+      nonce = await api.rpc.system.accountNextIndex(alice.address);
       await api.tx.cennzx
         .removeLiquidity(assetA, removeLiquidity, minAssetWithdraw, minCoreWithdraw)
-        .signAndSend(alice, async ({ events, status }) => {
+        .signAndSend(alice, { nonce }, async ({ events, status }) => {
           if (status.isFinalized && events !== undefined) {
             for (const { event } of events) {
               if (event.method === 'RemoveLiquidity') {

--- a/packages/api/src/derives/index.ts
+++ b/packages/api/src/derives/index.ts
@@ -21,10 +21,11 @@ import * as cennzx from './cennzx';
 import * as fees from './fees';
 import * as session from './session';
 import * as staking from './staking';
+import * as balances from './balances';
 
 export type DeriveFunc = (instanceId: string, api: ApiInterfaceRx) => (...args: any[]) => Observable<any>;
 
-export const derive = { attestation, cennzx, fees, staking, session };
+export const derive = { attestation, balances, cennzx, fees, staking, session };
 
 export type DecoratedCennznetDerive<
   ApiType extends ApiTypes,

--- a/packages/api/test/e2e/cennzx.e2e.ts
+++ b/packages/api/test/e2e/cennzx.e2e.ts
@@ -41,19 +41,21 @@ describe('CENNZX RPC calls testing', () => {
         const amount = 3_000_000;
         const coreAmount = amount;
         const minLiquidity = 1;
+        const nonce = await api.rpc.system.accountNextIndex(alice.address);
       // Add Liquidity for the first time in the pool.
         await api.tx.cennzx
           .addLiquidity(CENNZ, minLiquidity, amount, coreAmount)
-          .signAndSend(alice, async ({events, status}) => {
+          .signAndSend(alice, { nonce }, async ({events, status}) => {
             if (status.isFinalized) {
               for (const {event} of events) {
                 if (event.method === 'AddLiquidity') {
                   let amount = 20000;
                   const [coreAmount, investmentAmount] = await api.rpc.cennzx.liquidityPrice(CENNZ, amount);
+                  const nonce = await api.rpc.system.accountNextIndex(alice.address);
                   // Deposit liquidity in existing pool
                   await api.tx.cennzx
                       .addLiquidity(CENNZ, minLiquidity, investmentAmount, coreAmount)
-                      .signAndSend(alice, async ({events, status}) => {
+                      .signAndSend(alice, { nonce }, async ({events, status}) => {
                         if (status.isFinalized) {
                           for (const {event} of events) {
                             if (event.method === 'AddLiquidity') {
@@ -106,8 +108,9 @@ describe('CENNZX RPC calls testing', () => {
           const extrinsic = api.tx.genericAsset
             .transfer(CENNZ, bob.address, 10000);
           const feeFromQuery = await api.derive.fees.estimateFee({extrinsic, userFeeAssetId:CENTRAPAY});
+          const nonce = await api.rpc.system.accountNextIndex(alice.address);
 
-          await extrinsic.signAndSend(alice,  async ({events, status}) => {
+          await extrinsic.signAndSend(alice, { nonce }, async ({events, status}) => {
             if (status.isFinalized) {
               events.forEach(({phase, event: {data, method, section}}) => {
                 console.log('\t', phase.toString(), `: ${section}.${method}`, data.toString());
@@ -125,9 +128,10 @@ describe('CENNZX RPC calls testing', () => {
           const feeExchange = api.registry.createType('FeeExchange', {assetId, maxPayment}, 0);
           const transactionPayment = api.registry.createType('ChargeTransactionPayment', {tip: 0, feeExchange});
           const extrinsic = api.tx.treasury.reportAwesome('Fantastic Work', alice.address);
+          const nonce = await api.rpc.system.accountNextIndex(alice.address);
 
           const feeFromQuery = await api.derive.fees.estimateFee({extrinsic, userFeeAssetId: CENNZ, maxPayment});
-          await extrinsic.signAndSend(alice,  {transactionPayment}, async ({events, status}) => {
+          await extrinsic.signAndSend(alice, { nonce, transactionPayment }, async ({events, status}) => {
             if (status.isFinalized) {
               events.forEach(({phase, event: {data, method, section}}) => {
                 if (method === 'AssetBought') {

--- a/packages/api/test/e2e/queries.e2e.ts
+++ b/packages/api/test/e2e/queries.e2e.ts
@@ -86,6 +86,7 @@ describe('e2e queries', () => {
       keyring.addFromUri('//Alice');
       // Lookup from keyring (assuming we have added all, on --dev this would be `//Alice`)
       const sudoPair = keyring.getPair(sudoKey.toString());
+      const nonce = await api.rpc.system.accountNextIndex(sudoPair.address);
       const owner = api.registry.createType('Owner', 0); // Owner type is enum with 0 as none/null
       const permissions = api.registry.createType('PermissionsV1', { update: owner, mint: owner, burn: owner});
       const option = {initialIssuance : 0, permissions};
@@ -97,7 +98,7 @@ describe('e2e queries', () => {
             assetOption,
             assetInfo
           ))
-        .signAndSend(sudoPair);
+        .signAndSend(sudoPair, { nonce });
     }, 12000);
   });
 


### PR DESCRIPTION
For Sylo to use new API with Azalea rv36, need to patch balances as a derived module as it does not exist till rv36..
May be after upgrade, we can remove changes in this PR..
I am still thinking of any possible way to add test...