### PR TITLE
Add a minimal test suite for v36 backwards compatibility

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,15 +1,10 @@
-/**
- * TODO: create files based on env, and merge env setting with default settings
- *
- * module.exports = require(`./${process.env.NODE_ENV}`);
- */
-
 const defaultConfig = {
   apiTimeOut: 30000,
   wsProvider: {
     localhost: 'ws://localhost:9944',
     integration: 'ws://testnet_node_alice:9944',
-    e2e: 'wss://rimu.unfrastructure.io/public/ws',
+    integrationV36: 'ws://v36_node:9944',
+    e2e: 'wss://rimu.unfrastructure.io/public/ws'
   },
 };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,29 @@
 version: '3'
 services:
+  # dev node with runtime v37 and client 1.2.0
   testnet_node_alice:
     container_name: testnet_node_alice
     image: cennznet/cennznet:1.2.0
     command:
-      - --chain=dev
-      - --base-path=/mnt/node
-      - --alice
-      - --validator
+      - --dev
+      - --tmp
+      - --no-mdns
       - --unsafe-ws-external
       - --unsafe-rpc-external
-      - --rpc-cors=all
     ports:
       - '9933:9933'
       - '9944:9944'
-      - '30333:30333'
-    networks:
-      - api_testnet
-
+  # dev node with runtime v36 and client 1.1.1
+  v36_node:
+    container_name: v36_node
+    image: cennznet/cennznet:1.1.1
+    command:
+      - --dev
+      - --no-mdns
+      - --unsafe-ws-external
+    ports:
+      - '9945:9944'
+  # a node environment to run api / e2e test scripts
   api_test:
     container_name: api_test
     environment:
@@ -25,10 +31,4 @@ services:
     build:
       context: .
       dockerfile: api_test.Dockerfile
-    networks:
-      - api_testnet
     command: ['tail', '-f', '/dev/null']
-networks:
-  api_testnet:
-    external:
-      name: apijs_default

--- a/packages/api/src/derives/balances.ts
+++ b/packages/api/src/derives/balances.ts
@@ -34,14 +34,7 @@ function queryOldNonce(api: ApiInterfaceRx, accountId: AccountId): Observable<In
 }
 
 function queryCurrentNonce(api: ApiInterfaceRx, accountId: AccountId): Observable<Index> {
-  return api.query.system.account<AccountInfo | ITuple<[Index, AccountData]>>(accountId).pipe(
-    map(
-      (infoOrTuple): Index => {
-        const accountNonce = (infoOrTuple as AccountInfo).nonce || (infoOrTuple as [Index, AccountData])[0];
-        return accountNonce;
-      }
-    )
-  );
+  return api.rpc.system.accountNextIndex<Index>(accountId).pipe(map((accountNonce): Index => accountNonce));
 }
 
 export function account(

--- a/packages/api/src/derives/balances.ts
+++ b/packages/api/src/derives/balances.ts
@@ -18,8 +18,6 @@ import { DeriveBalancesAccount } from '@cennznet/api/derives/types';
 import { map, switchMap } from 'rxjs/operators';
 import { memo } from '@polkadot/api-derive/util';
 import { AccountId, Index } from '@cennznet/types';
-import { AccountData, AccountInfo } from '@polkadot/types/interfaces';
-import { ITuple } from '@polkadot/types/types';
 import { isFunction } from '@polkadot/util';
 
 function calcBalances(api: ApiInterfaceRx, [accountId, accountNonce]: [AccountId, Index]): DeriveBalancesAccount {

--- a/packages/api/src/derives/balances.ts
+++ b/packages/api/src/derives/balances.ts
@@ -1,0 +1,69 @@
+// Copyright 2020 Centrality Investments Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Adding this file to support extrinsic via rv36
+import { ApiInterfaceRx } from '@polkadot/api/types';
+import { Observable, of, combineLatest } from 'rxjs';
+import { DeriveBalancesAccount } from '@cennznet/api/derives/types';
+import { map, switchMap } from 'rxjs/operators';
+import { memo } from '@polkadot/api-derive/util';
+import { AccountId, Index } from '@cennznet/types';
+import { AccountData, AccountInfo } from '@polkadot/types/interfaces';
+import { ITuple } from '@polkadot/types/types';
+import { isFunction } from '@polkadot/util';
+
+function calcBalances(api: ApiInterfaceRx, [accountId, accountNonce]: [AccountId, Index]): DeriveBalancesAccount {
+  return {
+    accountId,
+    accountNonce,
+  };
+}
+// With runtime version <= 36, the way nonce is queried is as follows
+function queryOldNonce(api: ApiInterfaceRx, accountId: AccountId): Observable<Index> {
+  return api.query.system.accountNonce<Index>(accountId).pipe(map((accountNonce): Index => accountNonce));
+}
+
+function queryCurrentNonce(api: ApiInterfaceRx, accountId: AccountId): Observable<Index> {
+  return api.query.system.account<AccountInfo | ITuple<[Index, AccountData]>>(accountId).pipe(
+    map(
+      (infoOrTuple): Index => {
+        const accountNonce = (infoOrTuple as AccountInfo).nonce || (infoOrTuple as [Index, AccountData])[0];
+        return accountNonce;
+      }
+    )
+  );
+}
+
+export function account(
+  instanceId: string,
+  api: ApiInterfaceRx
+): (address: AccountId | string) => Observable<DeriveBalancesAccount> {
+  return memo(
+    instanceId,
+    (address: AccountId | string): Observable<DeriveBalancesAccount> =>
+      api.derive.accounts.accountId(address).pipe(
+        switchMap(
+          (accountId): Observable<[AccountId, Index]> =>
+            accountId
+              ? combineLatest([
+                  of(accountId),
+                  isFunction(api.query.system.account)
+                    ? (queryCurrentNonce(api, accountId) as Observable<Index>)
+                    : (queryOldNonce(api, accountId) as Observable<Index>),
+                ])
+              : of([api.registry.createType('AccountId'), api.registry.createType('Index')])
+        ),
+        map((result): DeriveBalancesAccount => calcBalances(api, result))
+      )
+  );
+}

--- a/packages/api/src/derives/index.ts
+++ b/packages/api/src/derives/index.ts
@@ -21,10 +21,11 @@ import * as cennzx from './cennzx';
 import * as fees from './fees';
 import * as session from './session';
 import * as staking from './staking';
+import * as balances from './balances';
 
 export type DeriveFunc = (instanceId: string, api: ApiInterfaceRx) => (...args: any[]) => Observable<any>;
 
-export const derive = { attestation, cennzx, fees, staking, session };
+export const derive = { attestation, balances, cennzx, fees, staking, session };
 
 export type DecoratedCennznetDerive<
   ApiType extends ApiTypes,

--- a/packages/api/src/derives/types.ts
+++ b/packages/api/src/derives/types.ts
@@ -1,4 +1,14 @@
-import { AccountId, EraIndex, Exposure, Keys, StakingLedger, ValidatorPrefs, RewardDestination } from '@cennznet/types';
+import {
+  AccountId,
+  EraIndex,
+  Exposure,
+  Keys,
+  StakingLedger,
+  ValidatorPrefs,
+  RewardDestination,
+  Index,
+  Balance,
+} from '@cennznet/types';
 import { ApiTypes, SubmittableExtrinsic } from '@cennznet/api/types';
 
 export interface DerivedStakingInfo {
@@ -23,4 +33,9 @@ export interface EstimateFeeParams {
   extrinsic: SubmittableExtrinsic<ApiTypes>;
   userFeeAssetId: string | number;
   maxPayment?: string;
+}
+
+export interface DeriveBalancesAccount {
+  accountId: AccountId;
+  accountNonce: Index;
 }

--- a/packages/api/src/derives/types.ts
+++ b/packages/api/src/derives/types.ts
@@ -7,7 +7,6 @@ import {
   ValidatorPrefs,
   RewardDestination,
   Index,
-  Balance,
 } from '@cennznet/types';
 import { ApiTypes, SubmittableExtrinsic } from '@cennznet/api/types';
 

--- a/packages/api/test/e2e/api.calls.e2e.ts
+++ b/packages/api/test/e2e/api.calls.e2e.ts
@@ -40,7 +40,7 @@ describe('e2e api calls', () => {
     expect(block.header.hash.toString()).toEqual(blockHash.toString());
   });
 
-  it.skip('Query historical block from runtime version 36', async () => {
+  it('Query historical block from runtime version 36', async () => {
     const blockNumber = 3759962; // old Azalea block at runtime version 36
     const API_KEY = process.env.API_KEY;
 
@@ -60,14 +60,13 @@ describe('e2e api calls', () => {
     await apiV36.disconnect();
   });
 
-  it.skip('Subscribe system events for runtime version 36', async done => {
+  it('Subscribe system events for runtime version 36', async done => {
     const API_KEY = process.env.API_KEY;
 
     const provider = `wss://node-6711773975684325376.jm.onfinality.io/ws?apikey=${API_KEY}`;
     const apiV36 = await Api.create({ provider });
     const blockHash = '0xcc1f072b8e76e330a9eb00315ad0bc7022623ffc02954b47d316e98dbba7fd64';
     const events = await apiV36.query.system.events.at(blockHash);
-    console.log('Events:', events.toJSON());
     const totalEvents = events.length;
     expect(totalEvents).toEqual(4);
     expect(events[0].event.section).toEqual('system');
@@ -78,6 +77,7 @@ describe('e2e api calls', () => {
     expect(events[2].event.method).toEqual('ExtrinsicSuccess');
     expect(events[3].event.section).toEqual('system');
     expect(events[3].event.method).toEqual('ExtrinsicSuccess');
+    await apiV36.disconnect();
     done();
   });
 

--- a/packages/api/test/e2e/api.v36-compat.e2e.ts
+++ b/packages/api/test/e2e/api.v36-compat.e2e.ts
@@ -1,0 +1,150 @@
+// Copyright 2019-2020 Centrality Investments Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Api as ApiPromise } from "@cennznet/api";
+import { AssetInfo, AssetOptions, Hash } from "@cennznet/types";
+import { SubmittableResult } from '@polkadot/api';
+import { Keyring } from '@polkadot/keyring';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+import config from '../../../../config';
+
+const keyring = new Keyring({ type: 'sr25519' });
+
+describe('runtime v36 compatibility', () => {
+  let api;
+  let alice, bob;
+  let stakingAssetId;
+
+  beforeAll(async () => {
+    await cryptoWaitReady();
+    const provider = process.env.TEST_TYPE?.toLowerCase() === 'integration' ? config.wsProvider.integrationV36 : 'ws://localhost:9945';
+    api = await ApiPromise.create({ provider });
+    console.log(`Ensure a node running v36 runtime is available at ${provider}`)
+    alice = keyring.addFromUri('//Alice');
+    bob = keyring.addFromUri('//Bob');
+
+    stakingAssetId = await api.query.genericAsset.stakingAssetId();
+  });
+
+  afterAll(async () => {
+    await api.disconnect();
+  });
+
+  describe('Make transactions', () => {
+
+    it('sign then send', async done => {
+      const nonce = await api.rpc.system.accountNextIndex(bob.address);
+      const tx = api.tx.genericAsset
+        .transfer(stakingAssetId, alice.address, 1)
+        .sign(bob, { nonce });
+      await tx.send(async ({ events, status }: SubmittableResult) => {
+        if (status.isInBlock) {
+          expect(events[0].event.method).toEqual('Transferred');
+          expect(events[0].event.section).toEqual('genericAsset');
+          done();
+        }
+      });
+    });
+
+    it('signAndSend', async done => {
+      await api.tx.genericAsset
+        .transfer(stakingAssetId, alice.address, 1)
+        .signAndSend(bob, async ({ events, status }: SubmittableResult) => {
+          if (status.isInBlock) {
+            expect(events[0].event.method).toEqual('Transferred');
+            expect(events[0].event.section).toEqual('genericAsset');
+            done();
+          }
+        });
+    });
+
+    it('with immortal era and nonce', async done => {
+        const nonce = await api.rpc.system.accountNextIndex(bob.address);
+        await api.tx.genericAsset
+          .transfer(stakingAssetId, alice.address, 100)
+          .signAndSend(bob, { nonce },
+            async ({ events, status }: SubmittableResult) => {
+              if (status.isInBlock) {
+                expect(events[0].event.method).toEqual('Transferred');
+                expect(events[0].event.section).toEqual('genericAsset');
+                done();
+              }
+            });
+      });
+
+    });
+
+    describe('Make queries', () => {
+        it('Queries runtime, rpc, state & extrinsics', (): void => {
+            expect(api.genesisHash).toBeDefined();
+            expect(api.runtimeMetadata).toBeDefined();
+            expect(api.runtimeVersion).toBeDefined();
+            expect(api.rpc).toBeDefined();
+            expect(api.query).toBeDefined();
+            expect(api.tx).toBeDefined();
+            expect(api.derive).toBeDefined();
+        });
+    
+        it('Queries correct balance', async () => {
+            const nextAssetId = await api.query.genericAsset.nextAssetId();
+            const blockHash = (await api.rpc.chain.getBlockHash()) as Hash;
+            const nextAssetIdAt = await api.query.genericAsset.nextAssetId.at(blockHash);
+            expect(nextAssetId.toString()).toEqual(nextAssetIdAt.toString());
+        });
+
+        it('Checks transaction payment', async done => {
+            const assetBalance = await api.query.genericAsset.freeBalance(16001, bob.address);
+            console.log('Balance before ', assetBalance.toString());
+            const ex = await api.tx.genericAsset
+            .transfer(16000, bob.address, 100);
+            const payment = await api.rpc.payment.queryInfo(ex.toHex());
+            console.log('Payment:', payment.partialFee.toString());
+            done();
+        });
+
+        it('Emits events when storage changes', async done => {
+            let unsubscribeFn;
+            let count = 0;
+            const reservedIdStart: number = 17000;
+            unsubscribeFn = await api.query.genericAsset.nextAssetId((result: any) => {
+            if (count === 0) {
+                expect(result.toNumber()).toBeGreaterThanOrEqual(reservedIdStart);
+                count += 1;
+            } else {
+                expect(result.toNumber()).toBeGreaterThanOrEqual(reservedIdStart);
+                unsubscribeFn();
+                done();
+            }
+            });
+            const sudoKey = await api.query.sudo.key();
+            const keyring = new Keyring({ type: 'sr25519' });
+            keyring.addFromUri('//Alice');
+            // Lookup from keyring (assuming we have added all, on --dev this would be `//Alice`)
+            const sudoPair = keyring.getPair(sudoKey.toString());
+            const owner = api.registry.createType('Owner', 0); // Owner type is enum with 0 as none/null
+            const permissions = api.registry.createType('PermissionsV1', { update: owner, mint: owner, burn: owner});
+            const option = {initialIssuance : 0, permissions};
+            const assetOption: AssetOptions = api.registry.createType('AssetOptions', option);
+            const assetInfo: AssetInfo = api.registry.createType('AssetInfo', {symbol: 'SYLO', decimalPlaces: 3});
+            await api.tx.sudo
+            .sudo(api.tx.genericAsset
+                .create(alice.address,
+                assetOption,
+                assetInfo
+                ))
+            .signAndSend(sudoPair);
+        }, 12000);
+    });
+
+});


### PR DESCRIPTION
band-aid fix for testing v36 backwards compatibility.

In future would be nice to run the API object through the entire suite for each different node/runtime version

Have added balances derived query to keep the code base backward compatible..