### PR TITLE
Fix dependencies in API package

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@cennznet/types": "^1.3.1",
+    "@cennznet/util": "^1.3.1",
     "@polkadot/api": "2.7.1",
     "@polkadot/metadata": "2.7.1",
     "@polkadot/rpc-core": "2.7.1",


### PR DESCRIPTION
@cennznet/util - is been used in https://github.com/cennznet/api.js/blob/674f3e22fa9dd4ff5a044d8127dc0c7628eeef1a/packages/api/src/derives/cennzx/utils/index.ts

Discovered this issue while using the new version in uncover project..
The reason for this issue is earlier @cennnznet/types had this dependencies.. But when we moved types generation in @cennznet/types.... we removed this dependency cause that was not required for @cennznet/types project.