### PR TITLE
Added extrinsicPayload in registry

### DIFF
--- a/packages/api/test/e2e/api.create.e2e.ts
+++ b/packages/api/test/e2e/api.create.e2e.ts
@@ -90,12 +90,12 @@ describe('e2e api create', () => {
       signedExtensions: ["CheckSpecVersion", "CheckTxVersion", "CheckGenesis", "CheckMortality", "CheckNonce", "CheckWeight", "ChargeTransactionPayment"],
       specVersion: "0x00000026",
       tip: null,
-      transactionPayment: {tip: 0, feeExchange},
+      transactionPayment: {tip: 2, feeExchange},
       transactionVersion: "0x00000005",
       version: 4
     };
     const extPayload = api.registry.createType('ExtrinsicPayload', payload, { version: 4 });
-    expect(extPayload.toHuman().transactionPayment).toEqual({tip: '0', feeExchange:{ FeeExchangeV1: { assetId: '16,000', maxPayment: '50.0000 mUnit' }}});
+    expect(extPayload.toHuman().transactionPayment).toEqual({tip: '2.0000 pUnit', feeExchange:{ FeeExchangeV1: { assetId: '16,000', maxPayment: '50.0000 mUnit' }}});
   });
 
 

--- a/packages/api/test/e2e/util/SingleAccountSigner.ts
+++ b/packages/api/test/e2e/util/SingleAccountSigner.ts
@@ -1,0 +1,54 @@
+// Copyright 2017-2021 @polkadot/api authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Signer, SignerResult } from '@polkadot/api/types';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import type { Registry, SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
+
+import { assert, hexToU8a, u8aToHex } from '@polkadot/util';
+
+let id = 0;
+
+export class SingleAccountSigner implements Signer {
+  readonly #keyringPair: KeyringPair;
+
+  readonly #registry: Registry;
+
+  readonly #signDelay: number;
+
+  constructor (registry: Registry, keyringPair: KeyringPair, signDelay = 0) {
+    this.#keyringPair = keyringPair;
+    this.#registry = registry;
+    this.#signDelay = signDelay;
+  }
+
+  async signPayload (payload: SignerPayloadJSON): Promise<SignerResult> {
+    assert(payload.address === this.#keyringPair.address, 'Signer does not have the keyringPair');
+
+    return new Promise((resolve): void => {
+      setTimeout((): void => {
+        const signed = this.#registry.createType('ExtrinsicPayload', payload, { version: payload.version }).sign(this.#keyringPair);
+
+        resolve({
+          id: ++id,
+          ...signed
+        });
+      }, this.#signDelay);
+    });
+  }
+
+  async signRaw ({ address, data }: SignerPayloadRaw): Promise<SignerResult> {
+    assert(address === this.#keyringPair.address, 'Signer does not have the keyringPair');
+
+    return new Promise((resolve): void => {
+      setTimeout((): void => {
+        const signature = u8aToHex(this.#keyringPair.sign(hexToU8a(data)));
+
+        resolve({
+          id: ++id,
+          signature
+        });
+      }, this.#signDelay);
+    });
+  }
+}

--- a/packages/types/src/interfaces/extrinsic/SignerPayload.ts
+++ b/packages/types/src/interfaces/extrinsic/SignerPayload.ts
@@ -97,8 +97,8 @@ export default class SignerPayload extends _Payload implements ISignerPayload {
       }
     }
 
-    if (tip) {
-      console.warn(`Unknown tip found, treating them as no-effect`);
+    if (!tip.isEmpty) {
+      console.warn(`Unknown tip: ${tip} found, treating them as no-effect`);
     }
 
     return {

--- a/packages/types/src/interfaces/extrinsic/SignerPayload.ts
+++ b/packages/types/src/interfaces/extrinsic/SignerPayload.ts
@@ -16,6 +16,7 @@ import { Compact, Struct, u8, Vec } from '@polkadot/types';
 import { Text } from '@polkadot/types/primitive/Text';
 import { Balance, BlockNumber, Call, ExtrinsicEra, Hash, RuntimeVersion } from '@polkadot/types/interfaces';
 import {
+  AnyJson,
   Codec,
   Constructor,
   ISignerPayload,
@@ -26,9 +27,10 @@ import { u8aToHex } from '@polkadot/util';
 
 import { Address, Index } from '../types';
 import { ChargeTransactionPayment } from '../transactionPayment';
+import {defaultExtensions, findUnknownExtensions} from "./signedExtensions";
 
 export interface SignerPayloadJSON extends SignerPayloadJSONBase {
-  transactionPayment?: string;
+  transactionPayment?: Record<string, AnyJson>;
 }
 
 export interface SignerPayloadType extends Codec {
@@ -81,12 +83,25 @@ export default class SignerPayload extends _Payload implements ISignerPayload {
       method,
       nonce,
       runtimeVersion: { specVersion, transactionVersion },
-      signedExtensions,
+      transactionPayment,
       version,
+      signedExtensions,
+      tip
     } = this;
 
+    if (signedExtensions) {
+      const unknown = findUnknownExtensions(signedExtensions.map(e => e.toString()));
+
+      if (unknown.length) {
+        console.warn(`Unknown signed extensions ${unknown.join(', ')} found, treating them as no-effect`);
+      }
+    }
+
+    if (tip) {
+      console.warn(`Unknown tip found, treating them as no-effect`);
+    }
+
     return {
-      signedExtensions: signedExtensions.map(e => e.toString()),
       address: address.toString(),
       blockHash: blockHash.toHex(),
       blockNumber: blockNumber.toHex(),
@@ -98,7 +113,9 @@ export default class SignerPayload extends _Payload implements ISignerPayload {
       // [[tip]] is contained within [[transactionPayment]]
       tip: null,
       transactionVersion: transactionVersion.toHex(),
+      transactionPayment: transactionPayment.toJSON(),
       version: version.toNumber(),
+      signedExtensions: defaultExtensions
     };
   }
 

--- a/packages/types/src/interfaces/extrinsic/SignerPayload.ts
+++ b/packages/types/src/interfaces/extrinsic/SignerPayload.ts
@@ -27,7 +27,7 @@ import { u8aToHex } from '@polkadot/util';
 
 import { Address, Index } from '../types';
 import { ChargeTransactionPayment } from '../transactionPayment';
-import {defaultExtensions, findUnknownExtensions} from "./signedExtensions";
+import { defaultExtensions } from "./signedExtensions";
 
 export interface SignerPayloadJSON extends SignerPayloadJSONBase {
   transactionPayment?: Record<string, AnyJson>;

--- a/packages/types/src/interfaces/extrinsic/SignerPayload.ts
+++ b/packages/types/src/interfaces/extrinsic/SignerPayload.ts
@@ -90,15 +90,11 @@ export default class SignerPayload extends _Payload implements ISignerPayload {
     } = this;
 
     if (signedExtensions) {
-      const unknown = findUnknownExtensions(signedExtensions.map(e => e.toString()));
-
-      if (unknown.length) {
-        console.warn(`Unknown signed extensions ${unknown.join(', ')} found, treating them as no-effect`);
-      }
+      console.warn(`custom signed extensions will be ignored`);
     }
 
     if (!tip.isEmpty) {
-      console.warn(`Unknown tip: ${tip} found, treating them as no-effect`);
+      console.warn(`ignoring tip. use transactionPayment.tip`);
     }
 
     return {

--- a/packages/types/src/interfaces/extrinsic/index.ts
+++ b/packages/types/src/interfaces/extrinsic/index.ts
@@ -15,4 +15,5 @@
 export { default as CENNZnetExtrinsicPayloadV1 } from './v1/ExtrinsicPayload';
 export { default as CENNZnetExtrinsicSignatureV1 } from './v1/ExtrinsicSignature';
 export { default as CENNZnetExtrinsicSignatureV0 } from './v0/ExtrinsicSignatureV0';
+export { default as CENNZnetExtrinsicPayloadV0 } from './v0/ExtrinsicPayloadV0';
 export { default as SignerPayload } from './SignerPayload';

--- a/packages/types/src/interfaces/injects.ts
+++ b/packages/types/src/interfaces/injects.ts
@@ -15,7 +15,13 @@
 // CENNZnet types for injection into a polkadot API session
 
 import { OverrideBundleType } from '@polkadot/types/types/registry';
-import { CENNZnetExtrinsicSignatureV1, CENNZnetExtrinsicSignatureV0, SignerPayload } from './extrinsic';
+import {
+  CENNZnetExtrinsicSignatureV1,
+  CENNZnetExtrinsicSignatureV0,
+  SignerPayload,
+  CENNZnetExtrinsicPayloadV1,
+  CENNZnetExtrinsicPayloadV0
+} from './extrinsic';
 import * as definitions from './definitions';
 
 const _types = {
@@ -39,12 +45,14 @@ export const typesBundle: OverrideBundleType = {
             DispatchClass: 'DispatchClassTo36',
             DispatchInfo: 'DispatchInfoTo36',
             ExtrinsicSignatureV4: CENNZnetExtrinsicSignatureV0,
+            ExtrinsicPayloadV4: CENNZnetExtrinsicPayloadV0
           },
         },
         {
           minmax: [37, undefined],
           types: {
             ExtrinsicSignatureV4: CENNZnetExtrinsicSignatureV1,
+            ExtrinsicPayloadV4: CENNZnetExtrinsicPayloadV1
           },
         },
       ],


### PR DESCRIPTION
Creating ExtrinsicPayload via api.registry should provide the payload object with transactionPayment option.