### PR TITLE
Prerelease/1.3.3 alpha.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         echo ::set-output name=tag_name::$(cat packages/api/package.json \
         | grep version \
         | head -1 \
-        | grep -E -o '[0-9|a-z|\.|\-]+')
+        | grep -E -o '[0-9|.]+\-*[a-z]*\.[0-9]+|]+')
     - name: make release branch
       uses: peterjgrainger/action-create-branch@v2.0.1
       env:


### PR DESCRIPTION
Corrected regex further...
The earlier one yielded - **version 1.3.3-alpha.1**
However we required 1.3.3-alpha.1
https://github.com/cennznet/api.js/runs/1923210924?check_suite_focus=true
Updated regex and tested locally
cat packages/api/package.json         | grep version         | head -1         | grep -E -o '[0-9|.]+\-*[a-z]*\.[0-9]+|]+'
tested with version **1.3.3** and **1.3.3-alpha.1**