### PR TITLE
Prevent trigger for github publish pipeline unless automerge label is…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
   release-to-github:
     needs:
     - merge-release-branch
+    # release to github only when its a prerelease branch and auto merge label is triggered
+    if: ${{ startsWith(github.head_ref, 'prerelease/') }} && ${{ github.event.label.name == 'automerge' }}
     runs-on: ubuntu-latest
     steps:
     # checkout merged branch


### PR DESCRIPTION
Prevent unnecessary publish to npm... 
example dependabot security bump - https://github.com/cennznet/api.js/pull/265/checks?check_run_id=2007563007