### PR TITLE
Copied staking derived queries from UI project

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ It represents the closest reasonable ESLint configuration to this
 project's original TSLint configuration.
 
 We recommend eventually switching this configuration to extend from
-the recommended rulesets in typescript-eslint. 
+the recommended rulesets in typescript-eslint.
 https://github.com/typescript-eslint/tslint-to-eslint-config/blob/master/docs/FAQs.md
 
 Happy linting! 💖
@@ -75,7 +75,7 @@ module.exports = {
         ],
         "import/no-extraneous-dependencies": "off",
         "import/order": "error",
-        "no-duplicate-imports": "error",
+        "import/no-duplicates": ["error", {"considerQueryString": true}],
         // "no-magic-numbers": "error",
         "no-return-await": "error",
         "no-undef-init": "error",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jest": "^26.6.3",
     "jest-environment-node": "^26.5.2",
     "lerna": "^3.13.1",
-    "prettier": "^1.13.5",
+    "prettier": "^2.2.1",
     "pretty-quick": "^1.11.1",
     "ts-jest": "^26.4.1",
     "ts-node": "^8.0.3",

--- a/packages/api/src/derives/staking/electedInfo.ts
+++ b/packages/api/src/derives/staking/electedInfo.ts
@@ -22,19 +22,18 @@ export function electedInfo(instanceId: string, api: ApiInterfaceRx): () => Obse
         switchMap(
           ({ nextElected, validators }): Observable<DeriveStakingElected> => {
             const allAccounts = combineAccounts(nextElected, validators);
+            const flags = { withExposure: true, withLedger: true, withPrefs: true };
 
             // @ts-ignore
-            return api.derive.staking
-              .queryMulti(allAccounts, { withExposure: true, withLedger: true, withPrefs: true })
-              .pipe(
-                map(
-                  (info): DeriveStakingElected => ({
-                    info,
-                    nextElected,
-                    validators,
-                  })
-                )
-              );
+            return api.derive.staking.queryMulti(allAccounts, flags).pipe(
+              map(
+                (info): DeriveStakingElected => ({
+                  info,
+                  nextElected,
+                  validators,
+                })
+              )
+            );
           }
         )
       )

--- a/packages/api/src/derives/staking/electedInfo.ts
+++ b/packages/api/src/derives/staking/electedInfo.ts
@@ -1,0 +1,44 @@
+// Copyright 2017-2020 @polkadot/api-derive authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Observable } from 'rxjs';
+import type { ApiInterfaceRx } from '@polkadot/api/types';
+import type { AccountId } from '@polkadot/types/interfaces';
+
+import { map, switchMap } from 'rxjs/operators';
+
+import { memo } from '@polkadot/api-derive/util';
+import type { DeriveStakingElected } from './types';
+
+function combineAccounts(nextElected: AccountId[], validators: AccountId[]): AccountId[] {
+  return [...nextElected].concat(...validators.filter((v) => !nextElected.find((n) => n.eq(v))));
+}
+
+export function electedInfo(instanceId: string, api: ApiInterfaceRx): () => Observable<DeriveStakingElected> {
+  return memo(
+    instanceId,
+    (): Observable<DeriveStakingElected> =>
+      api.derive.staking.validators().pipe(
+        switchMap(
+          ({ nextElected, validators }): Observable<DeriveStakingElected> =>
+            // @ts-ignore
+            api.derive.staking
+              .queryMulti(combineAccounts(nextElected, validators), {
+                withExposure: true,
+                withLedger: true,
+                withPrefs: true,
+              })
+              .pipe(
+                map(
+                  (info): DeriveStakingElected => ({
+                    // @ts-ignore
+                    info,
+                    nextElected,
+                    validators,
+                  })
+                )
+              )
+        )
+      )
+  );
+}

--- a/packages/api/src/derives/staking/electedInfo.ts
+++ b/packages/api/src/derives/staking/electedInfo.ts
@@ -20,24 +20,22 @@ export function electedInfo(instanceId: string, api: ApiInterfaceRx): () => Obse
     (): Observable<DeriveStakingElected> =>
       api.derive.staking.validators().pipe(
         switchMap(
-          ({ nextElected, validators }): Observable<DeriveStakingElected> =>
+          ({ nextElected, validators }): Observable<DeriveStakingElected> => {
+            const allAccounts = combineAccounts(nextElected, validators);
+
             // @ts-ignore
-            api.derive.staking
-              .queryMulti(combineAccounts(nextElected, validators), {
-                withExposure: true,
-                withLedger: true,
-                withPrefs: true,
-              })
+            return api.derive.staking
+              .queryMulti(allAccounts, { withExposure: true, withLedger: true, withPrefs: true })
               .pipe(
                 map(
                   (info): DeriveStakingElected => ({
-                    // @ts-ignore
                     info,
                     nextElected,
                     validators,
                   })
                 )
-              )
+              );
+          }
         )
       )
   );

--- a/packages/api/src/derives/staking/index.ts
+++ b/packages/api/src/derives/staking/index.ts
@@ -1,5 +1,6 @@
 export { queryStakingAccountInfo as accountInfo } from './stakingAccount';
-export * from '@polkadot/api-derive/staking/account';
-export * from '@polkadot/api-derive/staking/electedInfo';
-export * from '@polkadot/api-derive/staking/overview';
-export * from '@polkadot/api-derive/staking/validators';
+export * from './overview';
+export * from './query';
+export * from './stashes';
+export * from './validators';
+export * from './waitingInfo';

--- a/packages/api/src/derives/staking/overview.ts
+++ b/packages/api/src/derives/staking/overview.ts
@@ -1,0 +1,30 @@
+// Copyright 2017-2020 @polkadot/api-derive authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Observable } from 'rxjs';
+import type { ApiInterfaceRx } from '@polkadot/api/types';
+import type { DeriveStakingOverview } from '@polkadot/api-derive/types';
+
+import { combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { memo } from '@polkadot/api-derive/util';
+
+/**
+ * @description Retrieve the staking overview, including elected and points earned
+ */
+export function overview(instanceId: string, api: ApiInterfaceRx): () => Observable<DeriveStakingOverview> {
+  return memo(
+    instanceId,
+    (): Observable<DeriveStakingOverview> =>
+      combineLatest([api.derive.session.indexes(), api.derive.staking.validators()]).pipe(
+        map(
+          ([indexes, { nextElected, validators }]): DeriveStakingOverview => ({
+            ...indexes,
+            nextElected,
+            validators,
+          })
+        )
+      )
+  );
+}

--- a/packages/api/src/derives/staking/query.ts
+++ b/packages/api/src/derives/staking/query.ts
@@ -1,0 +1,191 @@
+// Copyright 2017-2020 @polkadot/api-derive authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Observable } from 'rxjs';
+import type { ApiInterfaceRx } from '@polkadot/api/types';
+import type { Option } from '@polkadot/types';
+import type {
+  AccountId,
+  EraIndex,
+  Exposure,
+  Nominations,
+  RewardDestination,
+  StakingLedger,
+  ValidatorPrefs,
+} from '@polkadot/types/interfaces';
+import type { ITuple } from '@polkadot/types/types';
+import type { DeriveStakingQuery } from '@polkadot/api-derive/types';
+
+import { combineLatest, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+
+import { isFunction } from '@polkadot/util';
+
+import { memo } from '@polkadot/api-derive/util';
+
+interface QueryFlags {
+  withDestination?: boolean;
+  withExposure?: boolean;
+  withLedger?: boolean;
+  withNominations?: boolean;
+  withPrefs?: boolean;
+}
+
+type MultiResult = [
+  Option<AccountId>,
+  Option<ITuple<[Nominations]> | Nominations>,
+  RewardDestination,
+  ITuple<[ValidatorPrefs]> | ValidatorPrefs,
+  Exposure
+];
+
+type MultiResultCombo = [Option<AccountId>, Option<Nominations>, RewardDestination, ValidatorPrefs, Exposure];
+
+function parseDetails(
+  stashId: AccountId,
+  [controllerIdOpt, nominatorsOpt, rewardDestination, validatorPrefs, exposure]: MultiResult,
+  stakingLedgerOpt: Option<StakingLedger>
+): DeriveStakingQuery {
+  const nominators = nominatorsOpt && nominatorsOpt.unwrapOr(null);
+  return {
+    accountId: stashId,
+    controllerId: controllerIdOpt && controllerIdOpt.unwrapOr(null),
+    exposure,
+    nominators: nominators ? (Array.isArray(nominators) ? nominators[0].targets : nominators.targets) : [],
+    rewardDestination,
+    stakingLedger: stakingLedgerOpt.unwrapOrDefault(),
+    stashId,
+    validatorPrefs: Array.isArray(validatorPrefs) ? validatorPrefs[0] : validatorPrefs,
+  };
+}
+
+function retrievePrev(api: ApiInterfaceRx, stashId: AccountId): Observable<MultiResult> {
+  return api.queryMulti<MultiResult>([
+    [api.query.staking.bonded, stashId],
+    [api.query.staking.nominators, stashId],
+    [api.query.rewards.payee, stashId],
+    [api.query.staking.validators, stashId],
+    [api.query.staking.stakers, stashId],
+  ]);
+}
+
+function retrieveCurr(
+  api: ApiInterfaceRx,
+  stashIds: AccountId[],
+  activeEra: EraIndex,
+  { withDestination, withExposure, withLedger, withNominations, withPrefs }: QueryFlags
+): Observable<MultiResultCombo[]> {
+  const emptyCont = api.registry.createType('Option<AccountId>');
+  const emptyNoms = api.registry.createType('Option<Nominations>');
+  const emptyRewa = api.registry.createType('RewardDestination');
+  const emptyExpo = api.registry.createType('Exposure');
+  const emptyPrefs = api.registry.createType('ValidatorPrefs');
+
+  return combineLatest([
+    withLedger ? api.query.staking.bonded.multi<Option<AccountId>>(stashIds) : of(stashIds.map(() => emptyCont)),
+    withNominations && api.query.staking.nominators
+      ? api.query.staking.nominators.multi<Option<Nominations>>(stashIds)
+      : of(stashIds.map(() => emptyNoms)),
+    withDestination ? api.query.rewards.payee.multi<RewardDestination>(stashIds) : of(stashIds.map(() => emptyRewa)),
+    withPrefs ? api.query.staking.validators.multi<ValidatorPrefs>(stashIds) : of(stashIds.map(() => emptyPrefs)),
+    withExposure
+      ? api.query.staking.erasStakers.multi<Exposure>(stashIds.map((stashId) => [activeEra, stashId]))
+      : of(stashIds.map(() => emptyExpo)),
+  ]).pipe(
+    map(([controllerIdOpt, nominatorsOpt, rewardDestination, validatorPrefs, exposure]): MultiResultCombo[] =>
+      controllerIdOpt.map(
+        (controllerIdOpt, index): MultiResultCombo => [
+          controllerIdOpt,
+          nominatorsOpt[index],
+          rewardDestination[index],
+          validatorPrefs[index],
+          exposure[index],
+        ]
+      )
+    )
+  );
+}
+
+function retrieveControllers(
+  api: ApiInterfaceRx,
+  optControllerIds: Option<AccountId>[]
+): Observable<Option<StakingLedger>[]> {
+  const ids = optControllerIds.filter((opt) => opt.isSome).map((opt) => opt.unwrap());
+  const emptyLed = api.registry.createType('Option<StakingLedger>');
+
+  if (!ids.length) {
+    return of(optControllerIds.map(() => emptyLed));
+  }
+
+  return api.query.staking.ledger.multi<Option<StakingLedger>>(ids).pipe(
+    map((optLedgers): Option<StakingLedger>[] => {
+      let offset = -1;
+
+      return optControllerIds.map((opt): Option<StakingLedger> => (opt.isSome ? optLedgers[++offset] : emptyLed));
+    })
+  );
+}
+
+/**
+ * @description From a stash, retrieve the controllerId and all relevant details
+ */
+export function query(
+  instanceId: string,
+  api: ApiInterfaceRx
+): (accountId: Uint8Array | string, flags: QueryFlags) => Observable<DeriveStakingQuery> {
+  return memo(
+    instanceId,
+    (accountId: Uint8Array | string, flags: QueryFlags): Observable<DeriveStakingQuery> =>
+      // @ts-ignore
+      api.derive.staking.queryMulti([accountId], flags).pipe(
+        // @ts-ignore
+        map(([first]) => first)
+      )
+  );
+}
+
+export function queryMulti(
+  instanceId: string,
+  api: ApiInterfaceRx
+): (accountIds: (Uint8Array | string)[], flags: QueryFlags) => Observable<DeriveStakingQuery[]> {
+  return memo(
+    instanceId,
+    (
+      accountIds: (Uint8Array | string)[],
+      flags: QueryFlags = {
+        withExposure: true,
+        withNominations: true,
+        withLedger: true,
+        withDestination: true,
+        withPrefs: true,
+      }
+    ): Observable<DeriveStakingQuery[]> =>
+      accountIds.length
+        ? api.derive.session.indexes().pipe(
+            switchMap(
+              ({ activeEra }): Observable<DeriveStakingQuery[]> => {
+                const stashIds = accountIds.map((accountId) => api.registry.createType('AccountId', accountId));
+                return (isFunction(api.query.staking.erasStakers)
+                  ? retrieveCurr(api, stashIds, activeEra, flags)
+                  : combineLatest(stashIds.map((stashId) => retrievePrev(api, stashId)))
+                ).pipe(
+                  switchMap(
+                    (results): Observable<DeriveStakingQuery[]> =>
+                      retrieveControllers(
+                        api,
+                        results.map(([optController]) => optController)
+                      ).pipe(
+                        map((stakingLedgerOpts) =>
+                          stashIds.map((stashId, index) =>
+                            parseDetails(stashId, results[index], stakingLedgerOpts[index])
+                          )
+                        )
+                      )
+                  )
+                );
+              }
+            )
+          )
+        : of([])
+  );
+}

--- a/packages/api/src/derives/staking/query.ts
+++ b/packages/api/src/derives/staking/query.ts
@@ -137,14 +137,11 @@ export function query(
     instanceId,
     (accountId: Uint8Array | string, flags: QueryFlags): Observable<DeriveStakingQuery> =>
       // @ts-ignore
-      api.derive.staking.queryMulti([accountId], flags).pipe(
-        // @ts-ignore
-        map(([first]) => first)
-      )
+      api.derive.staking.queryMulti([accountId], flags).pipe(map(([first]) => first))
   );
 }
 
-export function queryMulti(
+export function queryMulti1(
   instanceId: string,
   api: ApiInterfaceRx
 ): (accountIds: (Uint8Array | string)[], flags: QueryFlags) => Observable<DeriveStakingQuery[]> {

--- a/packages/api/src/derives/staking/stashes.ts
+++ b/packages/api/src/derives/staking/stashes.ts
@@ -1,0 +1,23 @@
+// Copyright 2017-2020 @polkadot/api-derive authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Observable } from 'rxjs';
+import type { ApiInterfaceRx } from '@polkadot/api/types';
+import type { AccountId } from '@polkadot/types/interfaces';
+
+import { map } from 'rxjs/operators';
+
+import { memo } from '@polkadot/api-derive/util';
+
+/**
+ * @description Retrieve the list of all validator stashes
+ */
+export function stashes(instanceId: string, api: ApiInterfaceRx): () => Observable<AccountId[]> {
+  return memo(
+    instanceId,
+    (): Observable<AccountId[]> =>
+      api.query.staking.validators
+        .keys()
+        .pipe(map((keys) => keys.map((key) => key.args[0] as AccountId).filter((a) => a)))
+  );
+}

--- a/packages/api/src/derives/staking/types.ts
+++ b/packages/api/src/derives/staking/types.ts
@@ -1,0 +1,30 @@
+// Copyright 2017-2020 @polkadot/api-derive authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AccountId, Exposure, RewardDestination, StakingLedger, ValidatorPrefs } from '@polkadot/types/interfaces';
+import type { DeriveSessionIndexes } from '@polkadot/api-derive/session/types';
+
+export interface DeriveStakingStash {
+  controllerId: AccountId | null;
+  exposure: Exposure;
+  nominators: AccountId[];
+  rewardDestination: RewardDestination;
+  stashId: AccountId;
+  validatorPrefs: ValidatorPrefs;
+}
+
+export interface DeriveStakingQuery extends DeriveStakingStash {
+  accountId: AccountId;
+  stakingLedger: StakingLedger;
+}
+
+export interface DeriveStakingElected {
+  info: DeriveStakingQuery[];
+  nextElected: AccountId[];
+  validators: AccountId[];
+}
+
+export interface DeriveStakingOverview extends DeriveSessionIndexes {
+  nextElected: AccountId[];
+  validators: AccountId[];
+}

--- a/packages/api/src/derives/staking/validators.ts
+++ b/packages/api/src/derives/staking/validators.ts
@@ -1,0 +1,50 @@
+// Copyright 2017-2020 @polkadot/api-derive authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Observable } from 'rxjs';
+import type { ApiInterfaceRx } from '@polkadot/api/types';
+import type { AccountId } from '@polkadot/types/interfaces';
+import type { DeriveStakingValidators } from '@polkadot/api-derive/types';
+
+import { combineLatest, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+
+import { memo } from '@polkadot/api-derive/util';
+
+export function nextElected(instanceId: string, api: ApiInterfaceRx): () => Observable<AccountId[]> {
+  return memo(
+    instanceId,
+    (): Observable<AccountId[]> =>
+      api.query.staking.erasStakers
+        ? api.derive.session.indexes().pipe(
+            // only populate for next era in the last session, so track both here - entries are not
+            // subscriptions, so we need a trigger - currentIndex acts as that trigger to refresh
+            switchMap(({ currentEra }) => api.query.staking.erasStakers.keys(currentEra)),
+            map((keys) => keys.map((key) => key.args[1] as AccountId))
+          )
+        : api.query.staking.currentElected<AccountId[]>()
+  );
+}
+
+/**
+ * @description Retrieve latest list of validators
+ */
+export function validators(instanceId: string, api: ApiInterfaceRx): () => Observable<DeriveStakingValidators> {
+  return memo(
+    instanceId,
+    (): Observable<DeriveStakingValidators> =>
+      // Sadly the node-template is (for some obscure reason) not comprehensive, so while the derive works
+      // in all actual real-world deployed chains, it does create some confusion for limited template chains
+      combineLatest([
+        api.query.session ? api.query.session.validators() : of([]),
+        api.query.staking ? api.derive.staking.nextElected() : of([]),
+      ]).pipe(
+        map(
+          ([validators, nextElected]): DeriveStakingValidators => ({
+            nextElected: nextElected.length ? nextElected : validators,
+            validators,
+          })
+        )
+      )
+  );
+}

--- a/packages/api/src/derives/staking/waitingInfo.ts
+++ b/packages/api/src/derives/staking/waitingInfo.ts
@@ -1,0 +1,37 @@
+// Copyright 2017-2020 @polkadot/api-derive authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Observable } from 'rxjs';
+import type { ApiInterfaceRx } from '@polkadot/api/types';
+import type { DeriveStakingWaiting } from '@polkadot/api-derive/types';
+
+import { combineLatest } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+
+import { memo } from '@polkadot/api-derive/util';
+import { DeriveStakingQuery } from './types';
+
+export function waitingInfo(instanceId: string, api: ApiInterfaceRx): () => Observable<DeriveStakingWaiting> {
+  return memo(
+    instanceId,
+    (): Observable<DeriveStakingWaiting> =>
+      combineLatest([api.derive.staking.validators(), api.derive.staking.stashes()]).pipe(
+        switchMap(
+          ([{ nextElected }, stashes]): Observable<DeriveStakingWaiting> => {
+            const elected = nextElected.map((a) => a.toString());
+            const waiting = stashes.filter((v) => !elected.includes(v.toString()));
+
+            // @ts-ignore
+            return api.derive.staking.queryMulti(waiting, { withLedger: true, withPrefs: true }).pipe(
+              map(
+                (info: DeriveStakingQuery[]): DeriveStakingWaiting => ({
+                  info,
+                  waiting,
+                })
+              )
+            );
+          }
+        )
+      )
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13583,10 +13583,15 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.13.5, prettier@^1.18.2:
+prettier@^1.18.2:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-error@^2.0.2:
   version "2.1.2"


### PR DESCRIPTION
Earlier the derived queries were added in UI project... With this PR, the api will be decorated with proper derived queries which are used in UI. 
Few things to mention..

1. Updated eslint rule for duplicate import  - 
https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md updated the duplicate import rule as we now have 
import type {xyz} from 'abc';
import {def} from 'abc'; 
false positive rule on import type - https://github.com/typescript-eslint/typescript-eslint/issues/2315

2. Updated prettier to latest version to support typescript 3.8 syntax (for example import type) 
https://github.com/prettier/prettier/issues/7263

3. For the new staking derived queries added, needed to add // @ts-ignore at few places as in parent (polkadot) same call is used with different argument... once we upgrade to latest polkadot version these can be removed...
