### PR TITLE
Doc generated from typedoc for derive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ api_docs
 .tmp
 tmp
 jest_cache
+deriveDocs

--- a/docs/cennznet/attestation.md
+++ b/docs/cennznet/attestation.md
@@ -12,6 +12,8 @@ The following sections contain the module details.
 
 - **[Events](#Events)**
 
+- **[Derive queries](#derive-queries)**
+
  
 # Storage
  
@@ -48,3 +50,121 @@ The following sections contain the module details.
 ### ClaimUpdated(`AccountId`, `AccountId`, `AttestationTopic`, `AttestationValue`)
  
 # RPC
+ 
+# Derive queries
+
+- **interface**: api.derive.attestation.function_name
+# Module: attestation/getClaim
+
+## Table of contents
+
+## Functions
+
+### getClaim
+
+▸ **getClaim**(`instanceId`, `api`): (`holder`: `string`, `issuer`: `string`, `topic`: `string`) => `Observable`<[`Claim`](attestation_types.md#claim)\>
+
+Retrieve a single claim made about a holder by the given issuer on a given topic.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+the claim
+
+▸ (`holder`, `issuer`, `topic`): `Observable`<[`Claim`](attestation_types.md#claim)\>
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `holder` | `string` | The claim holder address |
+| `issuer` | `string` | The claim issuer address |
+| `topic` | `string` | The claim topic |
+
+##### Returns
+
+`Observable`<[`Claim`](attestation_types.md#claim)\>
+
+#### Defined in
+
+[packages/api/src/derives/attestation/getClaim.ts:33](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/attestation/getClaim.ts#L33)
+
+# Module: attestation/getClaims
+
+## Table of contents
+
+## Functions
+
+### getClaims
+
+▸ **getClaims**(`instanceId`, `api`): (`holder`: `string`, `issuers`: `string`[], `topics`: `string`[]) => `Observable`<[`Claim`](attestation_types.md#claim)[]\>
+
+Get all claims made about a holder by the given issuers on the given topics.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`holder`, `issuers`, `topics`): `Observable`<[`Claim`](attestation_types.md#claim)[]\>
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `holder` | `string` | The claims' holder address |
+| `issuers` | `string`[] | A list of claim issuer addresses to include |
+| `topics` | `string`[] | A list of claim topics to include |
+
+##### Returns
+
+`Observable`<[`Claim`](attestation_types.md#claim)[]\>
+
+#### Defined in
+
+[packages/api/src/derives/attestation/getClaims.ts:29](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/attestation/getClaims.ts#L29)
+
+# Module: attestation/types
+
+## Table of contents
+
+### Type aliases
+
+- [Claim](attestation_types.md#claim)
+
+## Type aliases
+
+### Claim
+
+Ƭ **Claim**: `Object`
+
+A cryptographic claim about a holder address made by another issuing address.
+The claim is made on a certain `topic` with some `value`
+An alias for `AttestationValue`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `holder` | `string` |
+| `issuer` | `string` |
+| `topic` | `string` |
+| `value` | `AttestationValue` |
+
+#### Defined in
+
+[packages/api/src/derives/attestation/types.ts:22](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/attestation/types.ts#L22)

--- a/docs/cennznet/attestation.md
+++ b/docs/cennznet/attestation.md
@@ -56,30 +56,15 @@ The following sections contain the module details.
 - **interface**: api.derive.attestation.function_name
 # Module: attestation/getClaim
 
-## Table of contents
 
 ## Functions
 
 ### getClaim
 
-▸ **getClaim**(`instanceId`, `api`): (`holder`: `string`, `issuer`: `string`, `topic`: `string`) => `Observable`<[`Claim`](attestation_types.md#claim)\>
+▸ **getClaim**(`holder`: `string`, `issuer`: `string`, `topic`: `string`) => `Observable`<[`Claim`](attestation_types.md#claim)\>
 
 Retrieve a single claim made about a holder by the given issuer on a given topic.
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-the claim
-
-▸ (`holder`, `issuer`, `topic`): `Observable`<[`Claim`](attestation_types.md#claim)\>
 
 ##### Parameters
 
@@ -95,34 +80,19 @@ the claim
 
 #### Defined in
 
-[packages/api/src/derives/attestation/getClaim.ts:33](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/attestation/getClaim.ts#L33)
+[packages/api/src/derives/attestation/getClaim.ts:33](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/attestation/getClaim.ts#L33)
 
 # Module: attestation/getClaims
 
-## Table of contents
 
 ## Functions
 
 ### getClaims
 
-▸ **getClaims**(`instanceId`, `api`): (`holder`: `string`, `issuers`: `string`[], `topics`: `string`[]) => `Observable`<[`Claim`](attestation_types.md#claim)[]\>
+▸ **getClaims**(`holder`: `string`, `issuers`: `string`[], `topics`: `string`[]) => `Observable`<[`Claim`](attestation_types.md#claim)[]\>
 
 Get all claims made about a holder by the given issuers on the given topics.
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`holder`, `issuers`, `topics`): `Observable`<[`Claim`](attestation_types.md#claim)[]\>
-
-##### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
@@ -136,11 +106,10 @@ Get all claims made about a holder by the given issuers on the given topics.
 
 #### Defined in
 
-[packages/api/src/derives/attestation/getClaims.ts:29](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/attestation/getClaims.ts#L29)
+[packages/api/src/derives/attestation/getClaims.ts:29](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/attestation/getClaims.ts#L29)
 
 # Module: attestation/types
 
-## Table of contents
 
 ### Type aliases
 
@@ -167,4 +136,4 @@ An alias for `AttestationValue`
 
 #### Defined in
 
-[packages/api/src/derives/attestation/types.ts:22](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/attestation/types.ts#L22)
+[packages/api/src/derives/attestation/types.ts:22](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/attestation/types.ts#L22)

--- a/docs/cennznet/cennzx.md
+++ b/docs/cennznet/cennzx.md
@@ -144,30 +144,15 @@ The following sections contain the module details.
 - **interface**: api.derive.cennzx.function_name
 # Module: cennzx/assetWithdrawn
 
-## Table of contents
 
 ## Functions
 
 ### assetToWithdraw
 
-▸ **assetToWithdraw**(`instanceId`, `api`): (`assetId`: `AnyNumber`, `liquidity`: `AnyNumber`) => `Observable`<`Object`\>
+▸ **assetToWithdraw**(`assetId`: `AnyNumber`, `liquidity`: `AnyNumber`) => `Observable`<`Object`\>
 
 Given an asset Id and liquidity amount, the function returns the core and asset that can be withdrawn from exchange
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`assetId`, `liquidity`): `Observable`<`Object`\>
-
-##### Parameters
 
 | Name | Type |
 | :------ | :------ |
@@ -180,30 +165,16 @@ Given an asset Id and liquidity amount, the function returns the core and asset 
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/assetWithdrawn.ts:29](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/assetWithdrawn.ts#L29)
+[packages/api/src/derives/cennzx/assetWithdrawn.ts:29](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/assetWithdrawn.ts#L29)
 
 ___
 
 ### assetToWithdrawAt
 
-▸ **assetToWithdrawAt**(`instanceId`, `api`): (`hash`: `Hash`, `assetId`: `AnyNumber`, `liquidity`: `AnyNumber`) => `Observable`<`Object`\>
+▸ **assetToWithdrawAt**(`hash`: `Hash`, `assetId`: `AnyNumber`, `liquidity`: `AnyNumber`) => `Observable`<`Object`\>
 
 Given an asset Id and liquidity amount, the function returns the core and asset that can be withdrawn from exchange at a blockHash
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`hash`, `assetId`, `liquidity`): `Observable`<`Object`\>
-
-##### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
@@ -217,34 +188,19 @@ Given an asset Id and liquidity amount, the function returns the core and asset 
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/assetWithdrawn.ts:54](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/assetWithdrawn.ts#L54)
+[packages/api/src/derives/cennzx/assetWithdrawn.ts:54](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/assetWithdrawn.ts#L54)
 
 # Module: cennzx/exchangeAddress
 
-## Table of contents
 
 ## Functions
 
 ### exchangeAddress
 
-▸ **exchangeAddress**(`instanceId`, `api`): (`assetId`: `AnyNumber`) => `Observable`<`string`\>
+▸ **exchangeAddress**(`assetId`: `AnyNumber`) => `Observable`<`string`\>
 
 Returns the exchange address for a given assetId
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`assetId`): `Observable`<`string`\>
-
-##### Parameters
 
 | Name | Type |
 | :------ | :------ |
@@ -256,34 +212,19 @@ Returns the exchange address for a given assetId
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/exchangeAddress.ts:27](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/exchangeAddress.ts#L27)
+[packages/api/src/derives/cennzx/exchangeAddress.ts:27](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/exchangeAddress.ts#L27)
 
 # Module: cennzx/liquidityBalance
 
-## Table of contents
 
 ## Functions
 
 ### liquidityBalance
 
-▸ **liquidityBalance**(`instanceId`, `api`): (`assetId`: `AnyNumber`, `address`: `AnyAddress`) => `Observable`<`BN`\>
+▸ **liquidityBalance**(`assetId`: `AnyNumber`, `address`: `AnyAddress`) => `Observable`<`BN`\>
 
 Gets the liquidity balance for an asset Id
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`assetId`, `address`): `Observable`<`BN`\>
-
-##### Parameters
 
 | Name | Type |
 | :------ | :------ |
@@ -296,30 +237,16 @@ Gets the liquidity balance for an asset Id
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/liquidityBalance.ts:29](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/liquidityBalance.ts#L29)
+[packages/api/src/derives/cennzx/liquidityBalance.ts:29](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/liquidityBalance.ts#L29)
 
 ___
 
 ### liquidityBalanceAt
 
-▸ **liquidityBalanceAt**(`instanceId`, `api`): (`hash`: `Hash`, `assetId`: `AnyNumber`, `address`: `AnyAddress`) => `Observable`<`BN`\>
+▸ **liquidityBalanceAt**(`hash`: `Hash`, `assetId`: `AnyNumber`, `address`: `AnyAddress`) => `Observable`<`BN`\>
 
 Gets the liquidity balance for an asset Id at a given blockhash
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`hash`, `assetId`, `address`): `Observable`<`BN`\>
-
-##### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
@@ -333,34 +260,19 @@ Gets the liquidity balance for an asset Id at a given blockhash
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/liquidityBalance.ts:49](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/liquidityBalance.ts#L49)
+[packages/api/src/derives/cennzx/liquidityBalance.ts:49](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/liquidityBalance.ts#L49)
 
 # Module: cennzx/poolBalance
 
-## Table of contents
 
 ## Functions
 
 ### poolAssetBalance
 
-▸ **poolAssetBalance**(`instanceId`, `api`): (`assetId`: `AnyNumber`) => `Observable`<`Balance`\>
+▸ **poolAssetBalance**(`assetId`: `AnyNumber`) => `Observable`<`Balance`\>
 
 Returns the amount of asset in the exchange
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`assetId`): `Observable`<`Balance`\>
-
-##### Parameters
 
 | Name | Type |
 | :------ | :------ |
@@ -372,30 +284,16 @@ Returns the amount of asset in the exchange
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/poolBalance.ts:26](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/poolBalance.ts#L26)
+[packages/api/src/derives/cennzx/poolBalance.ts:26](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/poolBalance.ts#L26)
 
 ___
 
 ### poolAssetBalanceAt
 
-▸ **poolAssetBalanceAt**(`instanceId`, `api`): (`hash`: `Hash`, `assetId`: `AnyNumber`) => `Observable`<`Balance`\>
+▸ **poolAssetBalanceAt**(`hash`: `Hash`, `assetId`: `AnyNumber`) => `Observable`<`Balance`\>
 
 Returns the amount of asset in the exchange at a blockHash
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`hash`, `assetId`): `Observable`<`Balance`\>
-
-##### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
@@ -408,30 +306,16 @@ Returns the amount of asset in the exchange at a blockHash
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/poolBalance.ts:56](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/poolBalance.ts#L56)
+[packages/api/src/derives/cennzx/poolBalance.ts:56](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/poolBalance.ts#L56)
 
 ___
 
 ### poolCoreAssetBalance
 
-▸ **poolCoreAssetBalance**(`instanceId`, `api`): (`assetId`: `AnyNumber`) => `Observable`<`Balance`\>
+▸ **poolCoreAssetBalance**(`assetId`: `AnyNumber`) => `Observable`<`Balance`\>
 
 Returns the amount of core asset in the exchange for the asset
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`assetId`): `Observable`<`Balance`\>
-
-##### Parameters
 
 | Name | Type |
 | :------ | :------ |
@@ -443,30 +327,16 @@ Returns the amount of core asset in the exchange for the asset
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/poolBalance.ts:42](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/poolBalance.ts#L42)
+[packages/api/src/derives/cennzx/poolBalance.ts:42](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/poolBalance.ts#L42)
 
 ___
 
 ### poolCoreAssetBalanceAt
 
-▸ **poolCoreAssetBalanceAt**(`instanceId`, `api`): (`hash`: `Hash`, `assetId`: `AnyNumber`) => `Observable`<`Balance`\>
+▸ **poolCoreAssetBalanceAt**(`hash`: `Hash`, `assetId`: `AnyNumber`) => `Observable`<`Balance`\>
 
 Returns the amount of core asset in the exchange for the asset at a blockHash
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`hash`, `assetId`): `Observable`<`Balance`\>
-
-##### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
@@ -479,59 +349,30 @@ Returns the amount of core asset in the exchange for the asset at a blockHash
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/poolBalance.ts:73](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/poolBalance.ts#L73)
+[packages/api/src/derives/cennzx/poolBalance.ts:73](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/poolBalance.ts#L73)
 
 # Module: cennzx/shared
 
-## Table of contents
 
 ## Functions
 
 ### coreAssetId
 
-▸ **coreAssetId**(`instanceId`, `api`): () => `Observable`<`u32`\>
+▸ **coreAssetId**() => `Observable`<`u32`\>
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (): `Observable`<`u32`\>
-
-##### Returns
 
 `Observable`<`u32`\>
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/shared.ts:20](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/shared.ts#L20)
+[packages/api/src/derives/cennzx/shared.ts:20](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/shared.ts#L20)
 
 ___
 
 ### coreAssetIdAt
 
-▸ **coreAssetIdAt**(`instanceId`, `api`): (`hash`: `Hash`) => `Observable`<`u32`\>
+▸ **coreAssetIdAt**(`hash`: `Hash`) => `Observable`<`u32`\>
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`hash`): `Observable`<`u32`\>
-
-##### Parameters
 
 | Name | Type |
 | :------ | :------ |
@@ -543,55 +384,27 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/shared.ts:24](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/shared.ts#L24)
+[packages/api/src/derives/cennzx/shared.ts:24](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/shared.ts#L24)
 
 ___
 
 ### defaultFeeRate
 
-▸ **defaultFeeRate**(`instanceId`, `api`): () => `Observable`<`Permill`\>
+▸ **defaultFeeRate**() => `Observable`<`Permill`\>
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (): `Observable`<`Permill`\>
-
-##### Returns
 
 `Observable`<`Permill`\>
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/shared.ts:28](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/shared.ts#L28)
+[packages/api/src/derives/cennzx/shared.ts:28](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/shared.ts#L28)
 
 ___
 
 ### defaultFeeRateAt
 
-▸ **defaultFeeRateAt**(`instanceId`, `api`): (`hash`: `Hash`) => `Observable`<`Permill`\>
+▸ **defaultFeeRateAt**(`hash`: `Hash`) => `Observable`<`Permill`\>
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`hash`): `Observable`<`Permill`\>
-
-##### Parameters
 
 | Name | Type |
 | :------ | :------ |
@@ -603,34 +416,19 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/shared.ts:32](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/shared.ts#L32)
+[packages/api/src/derives/cennzx/shared.ts:32](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/shared.ts#L32)
 
 # Module: cennzx/totalLiquidity
 
-## Table of contents
 
 ## Functions
 
 ### totalLiquidity
 
-▸ **totalLiquidity**(`instanceId`, `api`): (`assetId`: `AnyNumber`) => `Observable`<`BN`\>
+▸ **totalLiquidity**(`assetId`: `AnyNumber`) => `Observable`<`BN`\>
 
 Returns the total liqudity in the exchange for the asset
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`assetId`): `Observable`<`BN`\>
-
-##### Parameters
 
 | Name | Type |
 | :------ | :------ |
@@ -642,30 +440,16 @@ Returns the total liqudity in the exchange for the asset
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/totalLiquidity.ts:27](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/totalLiquidity.ts#L27)
+[packages/api/src/derives/cennzx/totalLiquidity.ts:27](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/totalLiquidity.ts#L27)
 
 ___
 
 ### totalLiquidityAt
 
-▸ **totalLiquidityAt**(`instanceId`, `api`): (`hash`: `Hash`, `assetId`: `AnyNumber`) => `Observable`<`BN`\>
+▸ **totalLiquidityAt**(`hash`: `Hash`, `assetId`: `AnyNumber`) => `Observable`<`BN`\>
 
 Returns the total liqudity in the exchange for the asset at a blockHash
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`hash`, `assetId`): `Observable`<`BN`\>
-
-##### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
@@ -678,4 +462,4 @@ Returns the total liqudity in the exchange for the asset at a blockHash
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/totalLiquidity.ts:43](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/totalLiquidity.ts#L43)
+[packages/api/src/derives/cennzx/totalLiquidity.ts:43](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/cennzx/totalLiquidity.ts#L43)

--- a/docs/cennznet/cennzx.md
+++ b/docs/cennznet/cennzx.md
@@ -180,7 +180,7 @@ Given an asset Id and liquidity amount, the function returns the core and asset 
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/assetWithdrawn.ts:29](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/assetWithdrawn.ts#L29)
+[packages/api/src/derives/cennzx/assetWithdrawn.ts:29](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/assetWithdrawn.ts#L29)
 
 ___
 
@@ -217,7 +217,7 @@ Given an asset Id and liquidity amount, the function returns the core and asset 
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/assetWithdrawn.ts:54](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/assetWithdrawn.ts#L54)
+[packages/api/src/derives/cennzx/assetWithdrawn.ts:54](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/assetWithdrawn.ts#L54)
 
 # Module: cennzx/exchangeAddress
 
@@ -256,7 +256,7 @@ Returns the exchange address for a given assetId
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/exchangeAddress.ts:27](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/exchangeAddress.ts#L27)
+[packages/api/src/derives/cennzx/exchangeAddress.ts:27](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/exchangeAddress.ts#L27)
 
 # Module: cennzx/liquidityBalance
 
@@ -296,7 +296,7 @@ Gets the liquidity balance for an asset Id
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/liquidityBalance.ts:29](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/liquidityBalance.ts#L29)
+[packages/api/src/derives/cennzx/liquidityBalance.ts:29](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/liquidityBalance.ts#L29)
 
 ___
 
@@ -333,7 +333,7 @@ Gets the liquidity balance for an asset Id at a given blockhash
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/liquidityBalance.ts:49](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/liquidityBalance.ts#L49)
+[packages/api/src/derives/cennzx/liquidityBalance.ts:49](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/liquidityBalance.ts#L49)
 
 # Module: cennzx/poolBalance
 
@@ -372,7 +372,7 @@ Returns the amount of asset in the exchange
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/poolBalance.ts:26](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/poolBalance.ts#L26)
+[packages/api/src/derives/cennzx/poolBalance.ts:26](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/poolBalance.ts#L26)
 
 ___
 
@@ -408,7 +408,7 @@ Returns the amount of asset in the exchange at a blockHash
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/poolBalance.ts:56](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/poolBalance.ts#L56)
+[packages/api/src/derives/cennzx/poolBalance.ts:56](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/poolBalance.ts#L56)
 
 ___
 
@@ -443,7 +443,7 @@ Returns the amount of core asset in the exchange for the asset
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/poolBalance.ts:42](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/poolBalance.ts#L42)
+[packages/api/src/derives/cennzx/poolBalance.ts:42](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/poolBalance.ts#L42)
 
 ___
 
@@ -479,7 +479,7 @@ Returns the amount of core asset in the exchange for the asset at a blockHash
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/poolBalance.ts:73](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/poolBalance.ts#L73)
+[packages/api/src/derives/cennzx/poolBalance.ts:73](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/poolBalance.ts#L73)
 
 # Module: cennzx/shared
 
@@ -510,7 +510,7 @@ Returns the amount of core asset in the exchange for the asset at a blockHash
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/shared.ts:20](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/shared.ts#L20)
+[packages/api/src/derives/cennzx/shared.ts:20](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/shared.ts#L20)
 
 ___
 
@@ -543,7 +543,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/shared.ts:24](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/shared.ts#L24)
+[packages/api/src/derives/cennzx/shared.ts:24](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/shared.ts#L24)
 
 ___
 
@@ -570,7 +570,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/shared.ts:28](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/shared.ts#L28)
+[packages/api/src/derives/cennzx/shared.ts:28](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/shared.ts#L28)
 
 ___
 
@@ -603,7 +603,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/shared.ts:32](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/shared.ts#L32)
+[packages/api/src/derives/cennzx/shared.ts:32](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/shared.ts#L32)
 
 # Module: cennzx/totalLiquidity
 
@@ -642,7 +642,7 @@ Returns the total liqudity in the exchange for the asset
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/totalLiquidity.ts:27](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/totalLiquidity.ts#L27)
+[packages/api/src/derives/cennzx/totalLiquidity.ts:27](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/totalLiquidity.ts#L27)
 
 ___
 
@@ -678,4 +678,4 @@ Returns the total liqudity in the exchange for the asset at a blockHash
 
 #### Defined in
 
-[packages/api/src/derives/cennzx/totalLiquidity.ts:43](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/totalLiquidity.ts#L43)
+[packages/api/src/derives/cennzx/totalLiquidity.ts:43](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/cennzx/totalLiquidity.ts#L43)

--- a/docs/cennznet/cennzx.md
+++ b/docs/cennznet/cennzx.md
@@ -14,6 +14,8 @@ The following sections contain the module details.
 
 - **[RPC](#RPC)**
 
+- **[Derive queries](#derive-queries)**
+
  
 # Storage
  
@@ -136,3 +138,544 @@ The following sections contain the module details.
 - **interface**: `api.rpc.cennzx.sellPrice`
 - **jsonrpc**: `cennzx_sellPrice`
 - **summary**: Retrieves the spot exchange sell price
+ 
+# Derive queries
+
+- **interface**: api.derive.cennzx.function_name
+# Module: cennzx/assetWithdrawn
+
+## Table of contents
+
+## Functions
+
+### assetToWithdraw
+
+▸ **assetToWithdraw**(`instanceId`, `api`): (`assetId`: `AnyNumber`, `liquidity`: `AnyNumber`) => `Observable`<`Object`\>
+
+Given an asset Id and liquidity amount, the function returns the core and asset that can be withdrawn from exchange
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`assetId`, `liquidity`): `Observable`<`Object`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `assetId` | `AnyNumber` |
+| `liquidity` | `AnyNumber` |
+
+##### Returns
+
+`Observable`<`Object`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/assetWithdrawn.ts:29](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/assetWithdrawn.ts#L29)
+
+___
+
+### assetToWithdrawAt
+
+▸ **assetToWithdrawAt**(`instanceId`, `api`): (`hash`: `Hash`, `assetId`: `AnyNumber`, `liquidity`: `AnyNumber`) => `Observable`<`Object`\>
+
+Given an asset Id and liquidity amount, the function returns the core and asset that can be withdrawn from exchange at a blockHash
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`hash`, `assetId`, `liquidity`): `Observable`<`Object`\>
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `hash` | `Hash` | blockHash |
+| `assetId` | `AnyNumber` |  |
+| `liquidity` | `AnyNumber` | - |
+
+##### Returns
+
+`Observable`<`Object`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/assetWithdrawn.ts:54](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/assetWithdrawn.ts#L54)
+
+# Module: cennzx/exchangeAddress
+
+## Table of contents
+
+## Functions
+
+### exchangeAddress
+
+▸ **exchangeAddress**(`instanceId`, `api`): (`assetId`: `AnyNumber`) => `Observable`<`string`\>
+
+Returns the exchange address for a given assetId
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`assetId`): `Observable`<`string`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `assetId` | `AnyNumber` |
+
+##### Returns
+
+`Observable`<`string`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/exchangeAddress.ts:27](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/exchangeAddress.ts#L27)
+
+# Module: cennzx/liquidityBalance
+
+## Table of contents
+
+## Functions
+
+### liquidityBalance
+
+▸ **liquidityBalance**(`instanceId`, `api`): (`assetId`: `AnyNumber`, `address`: `AnyAddress`) => `Observable`<`BN`\>
+
+Gets the liquidity balance for an asset Id
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`assetId`, `address`): `Observable`<`BN`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `assetId` | `AnyNumber` |
+| `address` | `AnyAddress` |
+
+##### Returns
+
+`Observable`<`BN`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/liquidityBalance.ts:29](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/liquidityBalance.ts#L29)
+
+___
+
+### liquidityBalanceAt
+
+▸ **liquidityBalanceAt**(`instanceId`, `api`): (`hash`: `Hash`, `assetId`: `AnyNumber`, `address`: `AnyAddress`) => `Observable`<`BN`\>
+
+Gets the liquidity balance for an asset Id at a given blockhash
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`hash`, `assetId`, `address`): `Observable`<`BN`\>
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `hash` | `Hash` | blockHash |
+| `assetId` | `AnyNumber` |  |
+| `address` | `AnyAddress` |  |
+
+##### Returns
+
+`Observable`<`BN`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/liquidityBalance.ts:49](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/liquidityBalance.ts#L49)
+
+# Module: cennzx/poolBalance
+
+## Table of contents
+
+## Functions
+
+### poolAssetBalance
+
+▸ **poolAssetBalance**(`instanceId`, `api`): (`assetId`: `AnyNumber`) => `Observable`<`Balance`\>
+
+Returns the amount of asset in the exchange
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`assetId`): `Observable`<`Balance`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `assetId` | `AnyNumber` |
+
+##### Returns
+
+`Observable`<`Balance`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/poolBalance.ts:26](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/poolBalance.ts#L26)
+
+___
+
+### poolAssetBalanceAt
+
+▸ **poolAssetBalanceAt**(`instanceId`, `api`): (`hash`: `Hash`, `assetId`: `AnyNumber`) => `Observable`<`Balance`\>
+
+Returns the amount of asset in the exchange at a blockHash
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`hash`, `assetId`): `Observable`<`Balance`\>
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `hash` | `Hash` | blockHash |
+| `assetId` | `AnyNumber` |  |
+
+##### Returns
+
+`Observable`<`Balance`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/poolBalance.ts:56](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/poolBalance.ts#L56)
+
+___
+
+### poolCoreAssetBalance
+
+▸ **poolCoreAssetBalance**(`instanceId`, `api`): (`assetId`: `AnyNumber`) => `Observable`<`Balance`\>
+
+Returns the amount of core asset in the exchange for the asset
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`assetId`): `Observable`<`Balance`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `assetId` | `AnyNumber` |
+
+##### Returns
+
+`Observable`<`Balance`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/poolBalance.ts:42](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/poolBalance.ts#L42)
+
+___
+
+### poolCoreAssetBalanceAt
+
+▸ **poolCoreAssetBalanceAt**(`instanceId`, `api`): (`hash`: `Hash`, `assetId`: `AnyNumber`) => `Observable`<`Balance`\>
+
+Returns the amount of core asset in the exchange for the asset at a blockHash
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`hash`, `assetId`): `Observable`<`Balance`\>
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `hash` | `Hash` | blockHash |
+| `assetId` | `AnyNumber` |  |
+
+##### Returns
+
+`Observable`<`Balance`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/poolBalance.ts:73](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/poolBalance.ts#L73)
+
+# Module: cennzx/shared
+
+## Table of contents
+
+## Functions
+
+### coreAssetId
+
+▸ **coreAssetId**(`instanceId`, `api`): () => `Observable`<`u32`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (): `Observable`<`u32`\>
+
+##### Returns
+
+`Observable`<`u32`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/shared.ts:20](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/shared.ts#L20)
+
+___
+
+### coreAssetIdAt
+
+▸ **coreAssetIdAt**(`instanceId`, `api`): (`hash`: `Hash`) => `Observable`<`u32`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`hash`): `Observable`<`u32`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `hash` | `Hash` |
+
+##### Returns
+
+`Observable`<`u32`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/shared.ts:24](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/shared.ts#L24)
+
+___
+
+### defaultFeeRate
+
+▸ **defaultFeeRate**(`instanceId`, `api`): () => `Observable`<`Permill`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (): `Observable`<`Permill`\>
+
+##### Returns
+
+`Observable`<`Permill`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/shared.ts:28](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/shared.ts#L28)
+
+___
+
+### defaultFeeRateAt
+
+▸ **defaultFeeRateAt**(`instanceId`, `api`): (`hash`: `Hash`) => `Observable`<`Permill`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`hash`): `Observable`<`Permill`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `hash` | `Hash` |
+
+##### Returns
+
+`Observable`<`Permill`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/shared.ts:32](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/shared.ts#L32)
+
+# Module: cennzx/totalLiquidity
+
+## Table of contents
+
+## Functions
+
+### totalLiquidity
+
+▸ **totalLiquidity**(`instanceId`, `api`): (`assetId`: `AnyNumber`) => `Observable`<`BN`\>
+
+Returns the total liqudity in the exchange for the asset
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`assetId`): `Observable`<`BN`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `assetId` | `AnyNumber` |
+
+##### Returns
+
+`Observable`<`BN`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/totalLiquidity.ts:27](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/totalLiquidity.ts#L27)
+
+___
+
+### totalLiquidityAt
+
+▸ **totalLiquidityAt**(`instanceId`, `api`): (`hash`: `Hash`, `assetId`: `AnyNumber`) => `Observable`<`BN`\>
+
+Returns the total liqudity in the exchange for the asset at a blockHash
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`hash`, `assetId`): `Observable`<`BN`\>
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `hash` | `Hash` | blockHash |
+| `assetId` | `AnyNumber` |  |
+
+##### Returns
+
+`Observable`<`BN`\>
+
+#### Defined in
+
+[packages/api/src/derives/cennzx/totalLiquidity.ts:43](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/cennzx/totalLiquidity.ts#L43)

--- a/docs/cennznet/nft.md
+++ b/docs/cennznet/nft.md
@@ -14,6 +14,8 @@ The following sections contain the module details.
 
 - **[RPC](#RPC)**
 
+- **[Derive queries](#derive-queries)**
+
  
 # Storage
  
@@ -305,3 +307,203 @@ The following sections contain the module details.
 - **interface**: `api.rpc.nft.collectedTokens`
 - **jsonrpc**: `nft_collectedTokens`
 - **summary**: Get the tokens owned by an address in a certain collection
+ 
+# Derive queries
+
+- **interface**: api.derive.nft.function_name
+# Module: nft/collectionInfo
+
+## Table of contents
+
+## Functions
+
+### collectionInfo
+
+▸ **collectionInfo**(`instanceId`, `api`): () => `Observable`<[`CollectionInfo`](../interfaces/nft_types.collectioninfo.md)[]\>
+
+Get map of collection id to collection name
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+[CollectionInfo](../interfaces/nft_types.collectioninfo.md)
+
+▸ (): `Observable`<[`CollectionInfo`](../interfaces/nft_types.collectioninfo.md)[]\>
+
+##### Returns
+
+`Observable`<[`CollectionInfo`](../interfaces/nft_types.collectioninfo.md)[]\>
+
+#### Defined in
+
+[packages/api/src/derives/nft/collectionInfo.ts:13](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/collectionInfo.ts#L13)
+
+# Module: nft/openCollectionListings
+
+## Table of contents
+
+## Functions
+
+### openCollectionListings
+
+▸ **openCollectionListings**(`instanceId`, `api`): (`collectionId`: `string`) => `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
+
+Gets all tokens in a collection that have an open listing
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+List of tokens that have open listings in given collection
+
+▸ (`collectionId`): `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `collectionId` | `string` | The collection Id value |
+
+##### Returns
+
+`Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
+
+#### Defined in
+
+[packages/api/src/derives/nft/openCollectionListings.ts:30](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/openCollectionListings.ts#L30)
+
+# Module: nft/tokenInfo
+
+## Table of contents
+
+## Functions
+
+### tokenInfo
+
+▸ **tokenInfo**(`instanceId`, `api`): (`tokenId`: `TokenId` \| `EnhancedTokenId`) => `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)\>
+
+Get info on the current token
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+[[TokenInfo]]
+
+▸ (`tokenId`): `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)\>
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `tokenId` | `TokenId` \| `EnhancedTokenId` | The token Id value |
+
+##### Returns
+
+`Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)\>
+
+#### Defined in
+
+[packages/api/src/derives/nft/tokenInfo.ts:31](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/tokenInfo.ts#L31)
+
+___
+
+### tokensOf
+
+▸ **tokensOf**(`instanceId`, `api`): (`owner`: `string` \| `AccountId`, `collectionIds?`: `CollectionId`[]) => `Observable`<`EnhancedTokenId`[]\>
+
+Get info on the current token
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+[[EnchanceTokenId]]
+
+▸ (`owner`, `collectionIds?`): `Observable`<`EnhancedTokenId`[]\>
+
+##### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `owner` | `string` \| `AccountId` | The owner address |
+| `collectionIds?` | `CollectionId`[] | list of collectionIds [0,1,2..] (if not specified returns all the tokens in all the collections) |
+
+##### Returns
+
+`Observable`<`EnhancedTokenId`[]\>
+
+#### Defined in
+
+[packages/api/src/derives/nft/tokenInfo.ts:64](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/tokenInfo.ts#L64)
+
+# Module: nft/tokenInfoForCollection
+
+## Table of contents
+
+## Functions
+
+### tokenInfoForCollection
+
+▸ **tokenInfoForCollection**(`instanceId`, `api`): () => `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
+
+**`description`** Retrieve the list of all tokens in a collection
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (): `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
+
+##### Returns
+
+`Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
+
+#### Defined in
+
+[packages/api/src/derives/nft/tokenInfoForCollection.ts:28](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/tokenInfoForCollection.ts#L28)
+
+# Module: nft/types
+
+## Table of contents
+
+### Interfaces
+
+- [CollectionInfo](../interfaces/nft_types.collectioninfo.md)
+- [DeriveTokenInfo](../interfaces/nft_types.derivetokeninfo.md)

--- a/docs/cennznet/nft.md
+++ b/docs/cennznet/nft.md
@@ -313,30 +313,15 @@ The following sections contain the module details.
 - **interface**: api.derive.nft.function_name
 # Module: nft/collectionInfo
 
-## Table of contents
 
 ## Functions
 
 ### collectionInfo
 
-▸ **collectionInfo**(`instanceId`, `api`): () => `Observable`<[`CollectionInfo`](../interfaces/nft_types.collectioninfo.md)[]\>
+▸ **collectionInfo**() => `Observable`<[`CollectionInfo`](../interfaces/nft_types.collectioninfo.md)[]\>
 
 Get map of collection id to collection name
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-[CollectionInfo](../interfaces/nft_types.collectioninfo.md)
-
-▸ (): `Observable`<[`CollectionInfo`](../interfaces/nft_types.collectioninfo.md)[]\>
 
 ##### Returns
 
@@ -344,34 +329,19 @@ Get map of collection id to collection name
 
 #### Defined in
 
-[packages/api/src/derives/nft/collectionInfo.ts:13](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/collectionInfo.ts#L13)
+[packages/api/src/derives/nft/collectionInfo.ts:13](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/collectionInfo.ts#L13)
 
 # Module: nft/openCollectionListings
 
-## Table of contents
 
 ## Functions
 
 ### openCollectionListings
 
-▸ **openCollectionListings**(`instanceId`, `api`): (`collectionId`: `string`) => `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
+▸ **openCollectionListings**(`collectionId`: `string`) => `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
 
 Gets all tokens in a collection that have an open listing
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-List of tokens that have open listings in given collection
-
-▸ (`collectionId`): `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
 
 ##### Parameters
 
@@ -385,34 +355,19 @@ List of tokens that have open listings in given collection
 
 #### Defined in
 
-[packages/api/src/derives/nft/openCollectionListings.ts:30](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/openCollectionListings.ts#L30)
+[packages/api/src/derives/nft/openCollectionListings.ts:30](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/openCollectionListings.ts#L30)
 
 # Module: nft/tokenInfo
 
-## Table of contents
 
 ## Functions
 
 ### tokenInfo
 
-▸ **tokenInfo**(`instanceId`, `api`): (`tokenId`: `TokenId` \| `EnhancedTokenId`) => `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)\>
+▸ **tokenInfo**(`tokenId`: `TokenId` \| `EnhancedTokenId`) => `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)\>
 
 Get info on the current token
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-[[TokenInfo]]
-
-▸ (`tokenId`): `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)\>
 
 ##### Parameters
 
@@ -426,30 +381,16 @@ Get info on the current token
 
 #### Defined in
 
-[packages/api/src/derives/nft/tokenInfo.ts:31](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/tokenInfo.ts#L31)
+[packages/api/src/derives/nft/tokenInfo.ts:31](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/tokenInfo.ts#L31)
 
 ___
 
 ### tokensOf
 
-▸ **tokensOf**(`instanceId`, `api`): (`owner`: `string` \| `AccountId`, `collectionIds?`: `CollectionId`[]) => `Observable`<`EnhancedTokenId`[]\>
+▸ **tokensOf**(`owner`: `string` \| `AccountId`, `collectionIds?`: `CollectionId`[]) => `Observable`<`EnhancedTokenId`[]\>
 
 Get info on the current token
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-[[EnchanceTokenId]]
-
-▸ (`owner`, `collectionIds?`): `Observable`<`EnhancedTokenId`[]\>
 
 ##### Parameters
 
@@ -464,44 +405,28 @@ Get info on the current token
 
 #### Defined in
 
-[packages/api/src/derives/nft/tokenInfo.ts:64](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/tokenInfo.ts#L64)
+[packages/api/src/derives/nft/tokenInfo.ts:64](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/tokenInfo.ts#L64)
 
 # Module: nft/tokenInfoForCollection
 
-## Table of contents
 
 ## Functions
 
 ### tokenInfoForCollection
 
-▸ **tokenInfoForCollection**(`instanceId`, `api`): () => `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
+▸ **tokenInfoForCollection**() => `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
 
 **`description`** Retrieve the list of all tokens in a collection
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (): `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
-
-##### Returns
 
 `Observable`<[`DeriveTokenInfo`](../interfaces/nft_types.derivetokeninfo.md)[]\>
 
 #### Defined in
 
-[packages/api/src/derives/nft/tokenInfoForCollection.ts:28](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/tokenInfoForCollection.ts#L28)
+[packages/api/src/derives/nft/tokenInfoForCollection.ts:28](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/tokenInfoForCollection.ts#L28)
 
 # Module: nft/types
 
-## Table of contents
 
 ### Interfaces
 

--- a/docs/cennznet/nft.md
+++ b/docs/cennznet/nft.md
@@ -344,7 +344,7 @@ Get map of collection id to collection name
 
 #### Defined in
 
-[packages/api/src/derives/nft/collectionInfo.ts:13](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/collectionInfo.ts#L13)
+[packages/api/src/derives/nft/collectionInfo.ts:13](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/collectionInfo.ts#L13)
 
 # Module: nft/openCollectionListings
 
@@ -385,7 +385,7 @@ List of tokens that have open listings in given collection
 
 #### Defined in
 
-[packages/api/src/derives/nft/openCollectionListings.ts:30](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/openCollectionListings.ts#L30)
+[packages/api/src/derives/nft/openCollectionListings.ts:30](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/openCollectionListings.ts#L30)
 
 # Module: nft/tokenInfo
 
@@ -426,7 +426,7 @@ Get info on the current token
 
 #### Defined in
 
-[packages/api/src/derives/nft/tokenInfo.ts:31](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/tokenInfo.ts#L31)
+[packages/api/src/derives/nft/tokenInfo.ts:31](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/tokenInfo.ts#L31)
 
 ___
 
@@ -464,7 +464,7 @@ Get info on the current token
 
 #### Defined in
 
-[packages/api/src/derives/nft/tokenInfo.ts:64](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/tokenInfo.ts#L64)
+[packages/api/src/derives/nft/tokenInfo.ts:64](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/tokenInfo.ts#L64)
 
 # Module: nft/tokenInfoForCollection
 
@@ -497,7 +497,7 @@ Get info on the current token
 
 #### Defined in
 
-[packages/api/src/derives/nft/tokenInfoForCollection.ts:28](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/tokenInfoForCollection.ts#L28)
+[packages/api/src/derives/nft/tokenInfoForCollection.ts:28](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/tokenInfoForCollection.ts#L28)
 
 # Module: nft/types
 

--- a/docs/cennznet/staking.md
+++ b/docs/cennznet/staking.md
@@ -587,94 +587,49 @@ The following sections contain the module details.
 - **interface**: api.derive.staking.function_name
 # Module: staking/electedInfo
 
-## Table of contents
 
 ## Functions
 
 ### electedInfo
 
-▸ **electedInfo**(`instanceId`, `api`): () => `Observable`<[`DeriveStakingElected`](../interfaces/staking_types.derivestakingelected.md)\>
+▸ **electedInfo**() => `Observable`<[`DeriveStakingElected`](../interfaces/staking_types.derivestakingelected.md)\>
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (): `Observable`<[`DeriveStakingElected`](../interfaces/staking_types.derivestakingelected.md)\>
-
-##### Returns
 
 `Observable`<[`DeriveStakingElected`](../interfaces/staking_types.derivestakingelected.md)\>
 
 #### Defined in
 
-[packages/api/src/derives/staking/electedInfo.ts:17](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/electedInfo.ts#L17)
+[packages/api/src/derives/staking/electedInfo.ts:17](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/electedInfo.ts#L17)
 
 # Module: staking/overview
 
-## Table of contents
 
 ## Functions
 
 ### overview
 
-▸ **overview**(`instanceId`, `api`): () => `Observable`<`DeriveStakingOverview`\>
+▸ **overview**() => `Observable`<`DeriveStakingOverview`\>
 
 **`description`** Retrieve the staking overview, including elected and points earned
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (): `Observable`<`DeriveStakingOverview`\>
-
-##### Returns
 
 `Observable`<`DeriveStakingOverview`\>
 
 #### Defined in
 
-[packages/api/src/derives/staking/overview.ts:16](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/overview.ts#L16)
+[packages/api/src/derives/staking/overview.ts:16](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/overview.ts#L16)
 
 # Module: staking/stakingAccount
 
-## Table of contents
 
 ## Functions
 
 ### queryStakingAccountInfo
 
-▸ **queryStakingAccountInfo**(`instanceId`, `api`): (`accountId`: `Uint8Array` \| `string`, `activeEra`: `EraIndex`) => `Observable`<[`DerivedStakingInfo`](../interfaces/types.derivedstakinginfo.md)\>
+▸ **queryStakingAccountInfo**(`accountId`: `Uint8Array` \| `string`, `activeEra`: `EraIndex`) => `Observable`<[`DerivedStakingInfo`](../interfaces/types.derivedstakinginfo.md)\>
 
 **`description`** From a stash, retrieve the controller account ID and all relevant details
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (`accountId`, `activeEra`): `Observable`<[`DerivedStakingInfo`](../interfaces/types.derivedstakinginfo.md)\>
-
-##### Parameters
 
 | Name | Type |
 | :------ | :------ |
@@ -687,44 +642,28 @@ The following sections contain the module details.
 
 #### Defined in
 
-[packages/api/src/derives/staking/stakingAccount.ts:47](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/stakingAccount.ts#L47)
+[packages/api/src/derives/staking/stakingAccount.ts:47](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/stakingAccount.ts#L47)
 
 # Module: staking/stashes
 
-## Table of contents
 
 ## Functions
 
 ### stashes
 
-▸ **stashes**(`instanceId`, `api`): () => `Observable`<`AccountId`[]\>
+▸ **stashes**() => `Observable`<`AccountId`[]\>
 
 **`description`** Retrieve the list of all validator stashes
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (): `Observable`<`AccountId`[]\>
-
-##### Returns
 
 `Observable`<`AccountId`[]\>
 
 #### Defined in
 
-[packages/api/src/derives/staking/stashes.ts:15](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/stashes.ts#L15)
+[packages/api/src/derives/staking/stashes.ts:15](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/stashes.ts#L15)
 
 # Module: staking/types
 
-## Table of contents
 
 ### Interfaces
 
@@ -735,91 +674,47 @@ The following sections contain the module details.
 
 # Module: staking/validators
 
-## Table of contents
 
 ## Functions
 
 ### nextElected
 
-▸ **nextElected**(`instanceId`, `api`): () => `Observable`<`AccountId`[]\>
+▸ **nextElected**() => `Observable`<`AccountId`[]\>
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (): `Observable`<`AccountId`[]\>
-
-##### Returns
 
 `Observable`<`AccountId`[]\>
 
 #### Defined in
 
-[packages/api/src/derives/staking/validators.ts:14](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/validators.ts#L14)
+[packages/api/src/derives/staking/validators.ts:14](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/validators.ts#L14)
 
 ___
 
 ### validators
 
-▸ **validators**(`instanceId`, `api`): () => `Observable`<`DeriveStakingValidators`\>
+▸ **validators**() => `Observable`<`DeriveStakingValidators`\>
 
 **`description`** Retrieve latest list of validators
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (): `Observable`<`DeriveStakingValidators`\>
-
-##### Returns
 
 `Observable`<`DeriveStakingValidators`\>
 
 #### Defined in
 
-[packages/api/src/derives/staking/validators.ts:32](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/validators.ts#L32)
+[packages/api/src/derives/staking/validators.ts:32](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/validators.ts#L32)
 
 # Module: staking/waitingInfo
 
-## Table of contents
 
 ## Functions
 
 ### waitingInfo
 
-▸ **waitingInfo**(`instanceId`, `api`): () => `Observable`<`DeriveStakingWaiting`\>
+▸ **waitingInfo**() => `Observable`<`DeriveStakingWaiting`\>
 
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `instanceId` | `string` |
-| `api` | `ApiInterfaceRx` |
-
-#### Returns
-
-`fn`
-
-▸ (): `Observable`<`DeriveStakingWaiting`\>
-
-##### Returns
 
 `Observable`<`DeriveStakingWaiting`\>
 
 #### Defined in
 
-[packages/api/src/derives/staking/waitingInfo.ts:14](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/waitingInfo.ts#L14)
+[packages/api/src/derives/staking/waitingInfo.ts:14](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/waitingInfo.ts#L14)

--- a/docs/cennznet/staking.md
+++ b/docs/cennznet/staking.md
@@ -16,6 +16,8 @@ The following sections contain the module details.
 
 - **[RPC](#RPC)**
 
+- **[Derive queries](#derive-queries)**
+
  
 # Constant
  
@@ -579,3 +581,245 @@ The following sections contain the module details.
 - **interface**: `api.rpc.staking.accruedPayout`
 - **jsonrpc**: `staking_accruedPayout`
 - **summary**: Retrieves the currently accrued reward for the specified stash
+ 
+# Derive queries
+
+- **interface**: api.derive.staking.function_name
+# Module: staking/electedInfo
+
+## Table of contents
+
+## Functions
+
+### electedInfo
+
+▸ **electedInfo**(`instanceId`, `api`): () => `Observable`<[`DeriveStakingElected`](../interfaces/staking_types.derivestakingelected.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (): `Observable`<[`DeriveStakingElected`](../interfaces/staking_types.derivestakingelected.md)\>
+
+##### Returns
+
+`Observable`<[`DeriveStakingElected`](../interfaces/staking_types.derivestakingelected.md)\>
+
+#### Defined in
+
+[packages/api/src/derives/staking/electedInfo.ts:17](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/electedInfo.ts#L17)
+
+# Module: staking/overview
+
+## Table of contents
+
+## Functions
+
+### overview
+
+▸ **overview**(`instanceId`, `api`): () => `Observable`<`DeriveStakingOverview`\>
+
+**`description`** Retrieve the staking overview, including elected and points earned
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (): `Observable`<`DeriveStakingOverview`\>
+
+##### Returns
+
+`Observable`<`DeriveStakingOverview`\>
+
+#### Defined in
+
+[packages/api/src/derives/staking/overview.ts:16](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/overview.ts#L16)
+
+# Module: staking/stakingAccount
+
+## Table of contents
+
+## Functions
+
+### queryStakingAccountInfo
+
+▸ **queryStakingAccountInfo**(`instanceId`, `api`): (`accountId`: `Uint8Array` \| `string`, `activeEra`: `EraIndex`) => `Observable`<[`DerivedStakingInfo`](../interfaces/types.derivedstakinginfo.md)\>
+
+**`description`** From a stash, retrieve the controller account ID and all relevant details
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (`accountId`, `activeEra`): `Observable`<[`DerivedStakingInfo`](../interfaces/types.derivedstakinginfo.md)\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `accountId` | `Uint8Array` \| `string` |
+| `activeEra` | `EraIndex` |
+
+##### Returns
+
+`Observable`<[`DerivedStakingInfo`](../interfaces/types.derivedstakinginfo.md)\>
+
+#### Defined in
+
+[packages/api/src/derives/staking/stakingAccount.ts:47](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/stakingAccount.ts#L47)
+
+# Module: staking/stashes
+
+## Table of contents
+
+## Functions
+
+### stashes
+
+▸ **stashes**(`instanceId`, `api`): () => `Observable`<`AccountId`[]\>
+
+**`description`** Retrieve the list of all validator stashes
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (): `Observable`<`AccountId`[]\>
+
+##### Returns
+
+`Observable`<`AccountId`[]\>
+
+#### Defined in
+
+[packages/api/src/derives/staking/stashes.ts:15](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/stashes.ts#L15)
+
+# Module: staking/types
+
+## Table of contents
+
+### Interfaces
+
+- [DeriveStakingElected](../interfaces/staking_types.derivestakingelected.md)
+- [DeriveStakingOverview](../interfaces/staking_types.derivestakingoverview.md)
+- [DeriveStakingQuery](../interfaces/staking_types.derivestakingquery.md)
+- [DeriveStakingStash](../interfaces/staking_types.derivestakingstash.md)
+
+# Module: staking/validators
+
+## Table of contents
+
+## Functions
+
+### nextElected
+
+▸ **nextElected**(`instanceId`, `api`): () => `Observable`<`AccountId`[]\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (): `Observable`<`AccountId`[]\>
+
+##### Returns
+
+`Observable`<`AccountId`[]\>
+
+#### Defined in
+
+[packages/api/src/derives/staking/validators.ts:14](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/validators.ts#L14)
+
+___
+
+### validators
+
+▸ **validators**(`instanceId`, `api`): () => `Observable`<`DeriveStakingValidators`\>
+
+**`description`** Retrieve latest list of validators
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (): `Observable`<`DeriveStakingValidators`\>
+
+##### Returns
+
+`Observable`<`DeriveStakingValidators`\>
+
+#### Defined in
+
+[packages/api/src/derives/staking/validators.ts:32](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/validators.ts#L32)
+
+# Module: staking/waitingInfo
+
+## Table of contents
+
+## Functions
+
+### waitingInfo
+
+▸ **waitingInfo**(`instanceId`, `api`): () => `Observable`<`DeriveStakingWaiting`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `instanceId` | `string` |
+| `api` | `ApiInterfaceRx` |
+
+#### Returns
+
+`fn`
+
+▸ (): `Observable`<`DeriveStakingWaiting`\>
+
+##### Returns
+
+`Observable`<`DeriveStakingWaiting`\>
+
+#### Defined in
+
+[packages/api/src/derives/staking/waitingInfo.ts:14](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/waitingInfo.ts#L14)

--- a/docs/cennznet/staking.md
+++ b/docs/cennznet/staking.md
@@ -614,7 +614,7 @@ The following sections contain the module details.
 
 #### Defined in
 
-[packages/api/src/derives/staking/electedInfo.ts:17](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/electedInfo.ts#L17)
+[packages/api/src/derives/staking/electedInfo.ts:17](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/electedInfo.ts#L17)
 
 # Module: staking/overview
 
@@ -647,7 +647,7 @@ The following sections contain the module details.
 
 #### Defined in
 
-[packages/api/src/derives/staking/overview.ts:16](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/overview.ts#L16)
+[packages/api/src/derives/staking/overview.ts:16](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/overview.ts#L16)
 
 # Module: staking/stakingAccount
 
@@ -687,7 +687,7 @@ The following sections contain the module details.
 
 #### Defined in
 
-[packages/api/src/derives/staking/stakingAccount.ts:47](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/stakingAccount.ts#L47)
+[packages/api/src/derives/staking/stakingAccount.ts:47](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/stakingAccount.ts#L47)
 
 # Module: staking/stashes
 
@@ -720,7 +720,7 @@ The following sections contain the module details.
 
 #### Defined in
 
-[packages/api/src/derives/staking/stashes.ts:15](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/stashes.ts#L15)
+[packages/api/src/derives/staking/stashes.ts:15](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/stashes.ts#L15)
 
 # Module: staking/types
 
@@ -762,7 +762,7 @@ The following sections contain the module details.
 
 #### Defined in
 
-[packages/api/src/derives/staking/validators.ts:14](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/validators.ts#L14)
+[packages/api/src/derives/staking/validators.ts:14](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/validators.ts#L14)
 
 ___
 
@@ -791,7 +791,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/validators.ts:32](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/validators.ts#L32)
+[packages/api/src/derives/staking/validators.ts:32](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/validators.ts#L32)
 
 # Module: staking/waitingInfo
 
@@ -822,4 +822,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/waitingInfo.ts:14](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/waitingInfo.ts#L14)
+[packages/api/src/derives/staking/waitingInfo.ts:14](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/waitingInfo.ts#L14)

--- a/docs/interfaces/nft_types.collectioninfo.md
+++ b/docs/interfaces/nft_types.collectioninfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:27](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L27)
+[packages/api/src/derives/nft/types.ts:27](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/types.ts#L27)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:28](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L28)
+[packages/api/src/derives/nft/types.ts:28](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/types.ts#L28)

--- a/docs/interfaces/nft_types.collectioninfo.md
+++ b/docs/interfaces/nft_types.collectioninfo.md
@@ -1,0 +1,32 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [nft/types](../modules/nft_types.md) / CollectionInfo
+
+# Interface: CollectionInfo
+
+[nft/types](../modules/nft_types.md).CollectionInfo
+
+## Table of contents
+
+### Properties
+
+- [id](nft_types.collectioninfo.md#id)
+- [name](nft_types.collectioninfo.md#name)
+
+## Properties
+
+### id
+
+• **id**: `number`
+
+#### Defined in
+
+[packages/api/src/derives/nft/types.ts:27](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L27)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Defined in
+
+[packages/api/src/derives/nft/types.ts:28](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L28)

--- a/docs/interfaces/nft_types.collectioninfo.md
+++ b/docs/interfaces/nft_types.collectioninfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:27](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L27)
+[packages/api/src/derives/nft/types.ts:27](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L27)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:28](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L28)
+[packages/api/src/derives/nft/types.ts:28](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L28)

--- a/docs/interfaces/nft_types.derivetokeninfo.md
+++ b/docs/interfaces/nft_types.derivetokeninfo.md
@@ -1,0 +1,54 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [nft/types](../modules/nft_types.md) / DeriveTokenInfo
+
+# Interface: DeriveTokenInfo
+
+[nft/types](../modules/nft_types.md).DeriveTokenInfo
+
+## Table of contents
+
+### Properties
+
+- [attributes](nft_types.derivetokeninfo.md#attributes)
+- [listingId](nft_types.derivetokeninfo.md#listingid)
+- [owner](nft_types.derivetokeninfo.md#owner)
+- [tokenId](nft_types.derivetokeninfo.md#tokenid)
+
+## Properties
+
+### attributes
+
+• **attributes**: `NFTAttributeValue`[]
+
+#### Defined in
+
+[packages/api/src/derives/nft/types.ts:20](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L20)
+
+___
+
+### listingId
+
+• `Optional` **listingId**: `ListingId`
+
+#### Defined in
+
+[packages/api/src/derives/nft/types.ts:23](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L23)
+
+___
+
+### owner
+
+• **owner**: `string`
+
+#### Defined in
+
+[packages/api/src/derives/nft/types.ts:22](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L22)
+
+___
+
+### tokenId
+
+• **tokenId**: `EnhancedTokenId`
+
+#### Defined in
+
+[packages/api/src/derives/nft/types.ts:19](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L19)

--- a/docs/interfaces/nft_types.derivetokeninfo.md
+++ b/docs/interfaces/nft_types.derivetokeninfo.md
@@ -21,7 +21,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:20](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L20)
+[packages/api/src/derives/nft/types.ts:20](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/types.ts#L20)
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:23](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L23)
+[packages/api/src/derives/nft/types.ts:23](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/types.ts#L23)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:22](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L22)
+[packages/api/src/derives/nft/types.ts:22](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/types.ts#L22)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:19](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L19)
+[packages/api/src/derives/nft/types.ts:19](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/nft/types.ts#L19)

--- a/docs/interfaces/nft_types.derivetokeninfo.md
+++ b/docs/interfaces/nft_types.derivetokeninfo.md
@@ -21,7 +21,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:20](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L20)
+[packages/api/src/derives/nft/types.ts:20](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L20)
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:23](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L23)
+[packages/api/src/derives/nft/types.ts:23](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L23)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:22](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L22)
+[packages/api/src/derives/nft/types.ts:22](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L22)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/nft/types.ts:19](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/nft/types.ts#L19)
+[packages/api/src/derives/nft/types.ts:19](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/nft/types.ts#L19)

--- a/docs/interfaces/staking_types.derivestakingelected.md
+++ b/docs/interfaces/staking_types.derivestakingelected.md
@@ -1,0 +1,43 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [staking/types](../modules/staking_types.md) / DeriveStakingElected
+
+# Interface: DeriveStakingElected
+
+[staking/types](../modules/staking_types.md).DeriveStakingElected
+
+## Table of contents
+
+### Properties
+
+- [info](staking_types.derivestakingelected.md#info)
+- [nextElected](staking_types.derivestakingelected.md#nextelected)
+- [validators](staking_types.derivestakingelected.md#validators)
+
+## Properties
+
+### info
+
+• **info**: [`DeriveStakingQuery`](staking_types.derivestakingquery.md)[]
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:22](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L22)
+
+___
+
+### nextElected
+
+• **nextElected**: `AccountId`[]
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:23](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L23)
+
+___
+
+### validators
+
+• **validators**: `AccountId`[]
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:24](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L24)

--- a/docs/interfaces/staking_types.derivestakingelected.md
+++ b/docs/interfaces/staking_types.derivestakingelected.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:22](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L22)
+[packages/api/src/derives/staking/types.ts:22](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L22)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:23](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L23)
+[packages/api/src/derives/staking/types.ts:23](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L23)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:24](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L24)
+[packages/api/src/derives/staking/types.ts:24](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L24)

--- a/docs/interfaces/staking_types.derivestakingelected.md
+++ b/docs/interfaces/staking_types.derivestakingelected.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:22](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L22)
+[packages/api/src/derives/staking/types.ts:22](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L22)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:23](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L23)
+[packages/api/src/derives/staking/types.ts:23](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L23)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:24](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L24)
+[packages/api/src/derives/staking/types.ts:24](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L24)

--- a/docs/interfaces/staking_types.derivestakingoverview.md
+++ b/docs/interfaces/staking_types.derivestakingoverview.md
@@ -1,0 +1,113 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [staking/types](../modules/staking_types.md) / DeriveStakingOverview
+
+# Interface: DeriveStakingOverview
+
+[staking/types](../modules/staking_types.md).DeriveStakingOverview
+
+## Hierarchy
+
+- `DeriveSessionIndexes`
+
+  ↳ **`DeriveStakingOverview`**
+
+## Table of contents
+
+### Properties
+
+- [activeEra](staking_types.derivestakingoverview.md#activeera)
+- [activeEraStart](staking_types.derivestakingoverview.md#activeerastart)
+- [currentEra](staking_types.derivestakingoverview.md#currentera)
+- [currentIndex](staking_types.derivestakingoverview.md#currentindex)
+- [nextElected](staking_types.derivestakingoverview.md#nextelected)
+- [validatorCount](staking_types.derivestakingoverview.md#validatorcount)
+- [validators](staking_types.derivestakingoverview.md#validators)
+
+## Properties
+
+### activeEra
+
+• **activeEra**: `EraIndex`
+
+#### Inherited from
+
+DeriveSessionIndexes.activeEra
+
+#### Defined in
+
+node_modules/@polkadot/api-derive/session/types.d.ts:4
+
+___
+
+### activeEraStart
+
+• **activeEraStart**: `Option`<`Moment`\>
+
+#### Inherited from
+
+DeriveSessionIndexes.activeEraStart
+
+#### Defined in
+
+node_modules/@polkadot/api-derive/session/types.d.ts:5
+
+___
+
+### currentEra
+
+• **currentEra**: `EraIndex`
+
+#### Inherited from
+
+DeriveSessionIndexes.currentEra
+
+#### Defined in
+
+node_modules/@polkadot/api-derive/session/types.d.ts:6
+
+___
+
+### currentIndex
+
+• **currentIndex**: `SessionIndex`
+
+#### Inherited from
+
+DeriveSessionIndexes.currentIndex
+
+#### Defined in
+
+node_modules/@polkadot/api-derive/session/types.d.ts:7
+
+___
+
+### nextElected
+
+• **nextElected**: `AccountId`[]
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:28](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L28)
+
+___
+
+### validatorCount
+
+• **validatorCount**: `u32`
+
+#### Inherited from
+
+DeriveSessionIndexes.validatorCount
+
+#### Defined in
+
+node_modules/@polkadot/api-derive/session/types.d.ts:8
+
+___
+
+### validators
+
+• **validators**: `AccountId`[]
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:29](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L29)

--- a/docs/interfaces/staking_types.derivestakingoverview.md
+++ b/docs/interfaces/staking_types.derivestakingoverview.md
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:28](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L28)
+[packages/api/src/derives/staking/types.ts:28](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L28)
 
 ___
 
@@ -110,4 +110,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:29](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L29)
+[packages/api/src/derives/staking/types.ts:29](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L29)

--- a/docs/interfaces/staking_types.derivestakingoverview.md
+++ b/docs/interfaces/staking_types.derivestakingoverview.md
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:28](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L28)
+[packages/api/src/derives/staking/types.ts:28](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L28)
 
 ___
 
@@ -110,4 +110,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:29](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L29)
+[packages/api/src/derives/staking/types.ts:29](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L29)

--- a/docs/interfaces/staking_types.derivestakingquery.md
+++ b/docs/interfaces/staking_types.derivestakingquery.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:17](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L17)
+[packages/api/src/derives/staking/types.ts:17](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L17)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:8](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L8)
+[packages/api/src/derives/staking/types.ts:8](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L8)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:9](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L9)
+[packages/api/src/derives/staking/types.ts:9](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L9)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:10](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L10)
+[packages/api/src/derives/staking/types.ts:10](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L10)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:11](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L11)
+[packages/api/src/derives/staking/types.ts:11](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L11)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:18](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L18)
+[packages/api/src/derives/staking/types.ts:18](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L18)
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:12](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L12)
+[packages/api/src/derives/staking/types.ts:12](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L12)
 
 ___
 
@@ -125,4 +125,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:13](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L13)
+[packages/api/src/derives/staking/types.ts:13](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L13)

--- a/docs/interfaces/staking_types.derivestakingquery.md
+++ b/docs/interfaces/staking_types.derivestakingquery.md
@@ -1,0 +1,128 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [staking/types](../modules/staking_types.md) / DeriveStakingQuery
+
+# Interface: DeriveStakingQuery
+
+[staking/types](../modules/staking_types.md).DeriveStakingQuery
+
+## Hierarchy
+
+- [`DeriveStakingStash`](staking_types.derivestakingstash.md)
+
+  ↳ **`DeriveStakingQuery`**
+
+## Table of contents
+
+### Properties
+
+- [accountId](staking_types.derivestakingquery.md#accountid)
+- [controllerId](staking_types.derivestakingquery.md#controllerid)
+- [exposure](staking_types.derivestakingquery.md#exposure)
+- [nominators](staking_types.derivestakingquery.md#nominators)
+- [rewardDestination](staking_types.derivestakingquery.md#rewarddestination)
+- [stakingLedger](staking_types.derivestakingquery.md#stakingledger)
+- [stashId](staking_types.derivestakingquery.md#stashid)
+- [validatorPrefs](staking_types.derivestakingquery.md#validatorprefs)
+
+## Properties
+
+### accountId
+
+• **accountId**: `AccountId`
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:17](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L17)
+
+___
+
+### controllerId
+
+• **controllerId**: `AccountId`
+
+#### Inherited from
+
+[DeriveStakingStash](staking_types.derivestakingstash.md).[controllerId](staking_types.derivestakingstash.md#controllerid)
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:8](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L8)
+
+___
+
+### exposure
+
+• **exposure**: `Exposure`
+
+#### Inherited from
+
+[DeriveStakingStash](staking_types.derivestakingstash.md).[exposure](staking_types.derivestakingstash.md#exposure)
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:9](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L9)
+
+___
+
+### nominators
+
+• **nominators**: `AccountId`[]
+
+#### Inherited from
+
+[DeriveStakingStash](staking_types.derivestakingstash.md).[nominators](staking_types.derivestakingstash.md#nominators)
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:10](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L10)
+
+___
+
+### rewardDestination
+
+• **rewardDestination**: `RewardDestination`
+
+#### Inherited from
+
+[DeriveStakingStash](staking_types.derivestakingstash.md).[rewardDestination](staking_types.derivestakingstash.md#rewarddestination)
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:11](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L11)
+
+___
+
+### stakingLedger
+
+• **stakingLedger**: `StakingLedger`
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:18](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L18)
+
+___
+
+### stashId
+
+• **stashId**: `AccountId`
+
+#### Inherited from
+
+[DeriveStakingStash](staking_types.derivestakingstash.md).[stashId](staking_types.derivestakingstash.md#stashid)
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:12](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L12)
+
+___
+
+### validatorPrefs
+
+• **validatorPrefs**: `ValidatorPrefs`
+
+#### Inherited from
+
+[DeriveStakingStash](staking_types.derivestakingstash.md).[validatorPrefs](staking_types.derivestakingstash.md#validatorprefs)
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:13](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L13)

--- a/docs/interfaces/staking_types.derivestakingquery.md
+++ b/docs/interfaces/staking_types.derivestakingquery.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:17](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L17)
+[packages/api/src/derives/staking/types.ts:17](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L17)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:8](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L8)
+[packages/api/src/derives/staking/types.ts:8](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L8)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:9](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L9)
+[packages/api/src/derives/staking/types.ts:9](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L9)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:10](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L10)
+[packages/api/src/derives/staking/types.ts:10](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L10)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:11](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L11)
+[packages/api/src/derives/staking/types.ts:11](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L11)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:18](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L18)
+[packages/api/src/derives/staking/types.ts:18](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L18)
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:12](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L12)
+[packages/api/src/derives/staking/types.ts:12](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L12)
 
 ___
 
@@ -125,4 +125,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:13](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L13)
+[packages/api/src/derives/staking/types.ts:13](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L13)

--- a/docs/interfaces/staking_types.derivestakingstash.md
+++ b/docs/interfaces/staking_types.derivestakingstash.md
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:8](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L8)
+[packages/api/src/derives/staking/types.ts:8](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L8)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:9](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L9)
+[packages/api/src/derives/staking/types.ts:9](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L9)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:10](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L10)
+[packages/api/src/derives/staking/types.ts:10](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L10)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:11](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L11)
+[packages/api/src/derives/staking/types.ts:11](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L11)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:12](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L12)
+[packages/api/src/derives/staking/types.ts:12](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L12)
 
 ___
 
@@ -79,4 +79,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:13](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L13)
+[packages/api/src/derives/staking/types.ts:13](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/staking/types.ts#L13)

--- a/docs/interfaces/staking_types.derivestakingstash.md
+++ b/docs/interfaces/staking_types.derivestakingstash.md
@@ -1,0 +1,82 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [staking/types](../modules/staking_types.md) / DeriveStakingStash
+
+# Interface: DeriveStakingStash
+
+[staking/types](../modules/staking_types.md).DeriveStakingStash
+
+## Hierarchy
+
+- **`DeriveStakingStash`**
+
+  ↳ [`DeriveStakingQuery`](staking_types.derivestakingquery.md)
+
+## Table of contents
+
+### Properties
+
+- [controllerId](staking_types.derivestakingstash.md#controllerid)
+- [exposure](staking_types.derivestakingstash.md#exposure)
+- [nominators](staking_types.derivestakingstash.md#nominators)
+- [rewardDestination](staking_types.derivestakingstash.md#rewarddestination)
+- [stashId](staking_types.derivestakingstash.md#stashid)
+- [validatorPrefs](staking_types.derivestakingstash.md#validatorprefs)
+
+## Properties
+
+### controllerId
+
+• **controllerId**: `AccountId`
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:8](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L8)
+
+___
+
+### exposure
+
+• **exposure**: `Exposure`
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:9](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L9)
+
+___
+
+### nominators
+
+• **nominators**: `AccountId`[]
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:10](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L10)
+
+___
+
+### rewardDestination
+
+• **rewardDestination**: `RewardDestination`
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:11](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L11)
+
+___
+
+### stashId
+
+• **stashId**: `AccountId`
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:12](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L12)
+
+___
+
+### validatorPrefs
+
+• **validatorPrefs**: `ValidatorPrefs`
+
+#### Defined in
+
+[packages/api/src/derives/staking/types.ts:13](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L13)

--- a/docs/interfaces/staking_types.derivestakingstash.md
+++ b/docs/interfaces/staking_types.derivestakingstash.md
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:8](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L8)
+[packages/api/src/derives/staking/types.ts:8](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L8)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:9](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L9)
+[packages/api/src/derives/staking/types.ts:9](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L9)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:10](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L10)
+[packages/api/src/derives/staking/types.ts:10](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L10)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:11](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L11)
+[packages/api/src/derives/staking/types.ts:11](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L11)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:12](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L12)
+[packages/api/src/derives/staking/types.ts:12](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L12)
 
 ___
 
@@ -79,4 +79,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/staking/types.ts:13](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/staking/types.ts#L13)
+[packages/api/src/derives/staking/types.ts:13](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/staking/types.ts#L13)

--- a/docs/interfaces/types.derivebalancesaccount.md
+++ b/docs/interfaces/types.derivebalancesaccount.md
@@ -1,0 +1,32 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [types](../modules/types.md) / DeriveBalancesAccount
+
+# Interface: DeriveBalancesAccount
+
+[types](../modules/types.md).DeriveBalancesAccount
+
+## Table of contents
+
+### Properties
+
+- [accountId](types.derivebalancesaccount.md#accountid)
+- [accountNonce](types.derivebalancesaccount.md#accountnonce)
+
+## Properties
+
+### accountId
+
+• **accountId**: `AccountId`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:39](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L39)
+
+___
+
+### accountNonce
+
+• **accountNonce**: `Index`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:40](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L40)

--- a/docs/interfaces/types.derivebalancesaccount.md
+++ b/docs/interfaces/types.derivebalancesaccount.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:39](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L39)
+[packages/api/src/derives/types.ts:39](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L39)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:40](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L40)
+[packages/api/src/derives/types.ts:40](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L40)

--- a/docs/interfaces/types.derivebalancesaccount.md
+++ b/docs/interfaces/types.derivebalancesaccount.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:39](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L39)
+[packages/api/src/derives/types.ts:39](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L39)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:40](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L40)
+[packages/api/src/derives/types.ts:40](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L40)

--- a/docs/interfaces/types.derivedsessionkeyinfo.md
+++ b/docs/interfaces/types.derivedsessionkeyinfo.md
@@ -1,0 +1,32 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [types](../modules/types.md) / DerivedSessionKeyInfo
+
+# Interface: DerivedSessionKeyInfo
+
+[types](../modules/types.md).DerivedSessionKeyInfo
+
+## Table of contents
+
+### Properties
+
+- [nextSessionKeys](types.derivedsessionkeyinfo.md#nextsessionkeys)
+- [sessionKeys](types.derivedsessionkeyinfo.md#sessionkeys)
+
+## Properties
+
+### nextSessionKeys
+
+• **nextSessionKeys**: `AccountId`[]
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:28](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L28)
+
+___
+
+### sessionKeys
+
+• **sessionKeys**: `AccountId`[]
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:29](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L29)

--- a/docs/interfaces/types.derivedsessionkeyinfo.md
+++ b/docs/interfaces/types.derivedsessionkeyinfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:28](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L28)
+[packages/api/src/derives/types.ts:28](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L28)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:29](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L29)
+[packages/api/src/derives/types.ts:29](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L29)

--- a/docs/interfaces/types.derivedsessionkeyinfo.md
+++ b/docs/interfaces/types.derivedsessionkeyinfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:28](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L28)
+[packages/api/src/derives/types.ts:28](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L28)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:29](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L29)
+[packages/api/src/derives/types.ts:29](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L29)

--- a/docs/interfaces/types.derivedstakinginfo.md
+++ b/docs/interfaces/types.derivedstakinginfo.md
@@ -1,0 +1,120 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [types](../modules/types.md) / DerivedStakingInfo
+
+# Interface: DerivedStakingInfo
+
+[types](../modules/types.md).DerivedStakingInfo
+
+## Table of contents
+
+### Properties
+
+- [accountId](types.derivedstakinginfo.md#accountid)
+- [controllerId](types.derivedstakinginfo.md#controllerid)
+- [nextKeys](types.derivedstakinginfo.md#nextkeys)
+- [nominateAt](types.derivedstakinginfo.md#nominateat)
+- [nominators](types.derivedstakinginfo.md#nominators)
+- [rewardDestination](types.derivedstakinginfo.md#rewarddestination)
+- [stakers](types.derivedstakinginfo.md#stakers)
+- [stakingLedger](types.derivedstakinginfo.md#stakingledger)
+- [stashId](types.derivedstakinginfo.md#stashid)
+- [validatorPrefs](types.derivedstakinginfo.md#validatorprefs)
+
+## Properties
+
+### accountId
+
+• **accountId**: `AccountId`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:15](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L15)
+
+___
+
+### controllerId
+
+• `Optional` **controllerId**: `AccountId`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:16](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L16)
+
+___
+
+### nextKeys
+
+• `Optional` **nextKeys**: `Keys`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:20](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L20)
+
+___
+
+### nominateAt
+
+• `Optional` **nominateAt**: `EraIndex`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:18](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L18)
+
+___
+
+### nominators
+
+• `Optional` **nominators**: `AccountId`[]
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:17](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L17)
+
+___
+
+### rewardDestination
+
+• `Optional` **rewardDestination**: `RewardDestination`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:19](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L19)
+
+___
+
+### stakers
+
+• `Optional` **stakers**: `Exposure`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:21](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L21)
+
+___
+
+### stakingLedger
+
+• `Optional` **stakingLedger**: `StakingLedger`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:24](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L24)
+
+___
+
+### stashId
+
+• `Optional` **stashId**: `AccountId`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:22](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L22)
+
+___
+
+### validatorPrefs
+
+• `Optional` **validatorPrefs**: `ValidatorPrefs`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:23](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L23)

--- a/docs/interfaces/types.derivedstakinginfo.md
+++ b/docs/interfaces/types.derivedstakinginfo.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:15](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L15)
+[packages/api/src/derives/types.ts:15](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L15)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:16](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L16)
+[packages/api/src/derives/types.ts:16](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L16)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:20](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L20)
+[packages/api/src/derives/types.ts:20](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L20)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:18](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L18)
+[packages/api/src/derives/types.ts:18](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L18)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:17](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L17)
+[packages/api/src/derives/types.ts:17](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L17)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:19](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L19)
+[packages/api/src/derives/types.ts:19](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L19)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:21](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L21)
+[packages/api/src/derives/types.ts:21](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L21)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:24](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L24)
+[packages/api/src/derives/types.ts:24](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L24)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:22](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L22)
+[packages/api/src/derives/types.ts:22](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L22)
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:23](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L23)
+[packages/api/src/derives/types.ts:23](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L23)

--- a/docs/interfaces/types.derivedstakinginfo.md
+++ b/docs/interfaces/types.derivedstakinginfo.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:15](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L15)
+[packages/api/src/derives/types.ts:15](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L15)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:16](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L16)
+[packages/api/src/derives/types.ts:16](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L16)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:20](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L20)
+[packages/api/src/derives/types.ts:20](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L20)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:18](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L18)
+[packages/api/src/derives/types.ts:18](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L18)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:17](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L17)
+[packages/api/src/derives/types.ts:17](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L17)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:19](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L19)
+[packages/api/src/derives/types.ts:19](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L19)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:21](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L21)
+[packages/api/src/derives/types.ts:21](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L21)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:24](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L24)
+[packages/api/src/derives/types.ts:24](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L24)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:22](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L22)
+[packages/api/src/derives/types.ts:22](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L22)
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:23](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L23)
+[packages/api/src/derives/types.ts:23](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L23)

--- a/docs/interfaces/types.estimatefeeparams.md
+++ b/docs/interfaces/types.estimatefeeparams.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:33](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L33)
+[packages/api/src/derives/types.ts:33](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L33)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:35](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L35)
+[packages/api/src/derives/types.ts:35](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L35)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:34](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L34)
+[packages/api/src/derives/types.ts:34](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L34)

--- a/docs/interfaces/types.estimatefeeparams.md
+++ b/docs/interfaces/types.estimatefeeparams.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:33](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L33)
+[packages/api/src/derives/types.ts:33](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L33)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:35](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L35)
+[packages/api/src/derives/types.ts:35](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L35)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:34](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L34)
+[packages/api/src/derives/types.ts:34](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L34)

--- a/docs/interfaces/types.estimatefeeparams.md
+++ b/docs/interfaces/types.estimatefeeparams.md
@@ -1,0 +1,43 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [types](../modules/types.md) / EstimateFeeParams
+
+# Interface: EstimateFeeParams
+
+[types](../modules/types.md).EstimateFeeParams
+
+## Table of contents
+
+### Properties
+
+- [extrinsic](types.estimatefeeparams.md#extrinsic)
+- [maxPayment](types.estimatefeeparams.md#maxpayment)
+- [userFeeAssetId](types.estimatefeeparams.md#userfeeassetid)
+
+## Properties
+
+### extrinsic
+
+• **extrinsic**: `SubmittableExtrinsic`<`ApiTypes`, `ISubmittableResult`\> \| `default`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:33](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L33)
+
+___
+
+### maxPayment
+
+• `Optional` **maxPayment**: `string`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:35](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L35)
+
+___
+
+### userFeeAssetId
+
+• **userFeeAssetId**: `string` \| `number`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:34](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L34)

--- a/docs/interfaces/types.paymentoptions.md
+++ b/docs/interfaces/types.paymentoptions.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:44](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L44)
+[packages/api/src/derives/types.ts:44](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L44)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:45](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L45)
+[packages/api/src/derives/types.ts:45](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L45)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:46](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L46)
+[packages/api/src/derives/types.ts:46](https://github.com/cennznet/api.js/blob/ed0f396/packages/api/src/derives/types.ts#L46)

--- a/docs/interfaces/types.paymentoptions.md
+++ b/docs/interfaces/types.paymentoptions.md
@@ -1,0 +1,43 @@
+[@cennznet/api](../README.md) / [Exports](../modules.md) / [types](../modules/types.md) / PaymentOptions
+
+# Interface: PaymentOptions
+
+[types](../modules/types.md).PaymentOptions
+
+## Table of contents
+
+### Properties
+
+- [feeAssetId](types.paymentoptions.md#feeassetid)
+- [slippage](types.paymentoptions.md#slippage)
+- [tip](types.paymentoptions.md#tip)
+
+## Properties
+
+### feeAssetId
+
+• **feeAssetId**: `string` \| `number`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:44](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L44)
+
+___
+
+### slippage
+
+• `Optional` **slippage**: `number`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:45](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L45)
+
+___
+
+### tip
+
+• `Optional` **tip**: `number`
+
+#### Defined in
+
+[packages/api/src/derives/types.ts:46](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L46)

--- a/docs/interfaces/types.paymentoptions.md
+++ b/docs/interfaces/types.paymentoptions.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:44](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L44)
+[packages/api/src/derives/types.ts:44](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L44)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:45](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L45)
+[packages/api/src/derives/types.ts:45](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L45)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/api/src/derives/types.ts:46](https://github.com/cennznet/api.js/blob/7367fb0/packages/api/src/derives/types.ts#L46)
+[packages/api/src/derives/types.ts:46](https://github.com/cennznet/api.js/blob/1844291/packages/api/src/derives/types.ts#L46)

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "scripts": {
     "build": "polkadot-dev-build-ts",
     "clean": "polkadot-dev-clean-build",
-    "docs:meta": "node ./scripts/metadataMdWrapper.js",
+    "docs:meta": "yarn run docs:derive && cp -rf deriveDocs/interfaces docs && node ./scripts/metadataMdWrapper.js",
     "docs:src": "rm -rf api_docs && typedoc --plugin typedoc-plugin-markdown --options typedoc.config.js .",
+    "docs:derive": "npx typedoc packages/api/src/derives/ --out deriveDocs  --exclude  '**/*+(index|.e2e|balances).ts'",
     "meta:slim": "node ./scripts/generateSlimMetadataWrapper",
     "meta:update": "node ./scripts/updateStaticMetadata packages/api/src packages/types && pushd packages/types && yarn build && popd && yarn docs:meta",
     "lint": "eslint . --ext .ts",
@@ -46,7 +47,7 @@
     "ts-jest": "^26.4.1",
     "ts-node": "^8.0.3",
     "tsconfig-paths": "^3.8.0",
-    "typedoc": "^0.19.2",
+    "typedoc": "0.21.0",
     "typescript": "^4.0.3"
   },
   "resolutions": {
@@ -64,6 +65,6 @@
     }
   },
   "dependencies": {
-    "typedoc-plugin-markdown": "^2.2.17"
+    "typedoc-plugin-markdown": "^3.10.0"
   }
 }

--- a/scripts/MetadataMd.ts
+++ b/scripts/MetadataMd.ts
@@ -341,7 +341,7 @@ function addModule(metadata: MetadataLatest, name, displayName): string {
                   name: `${methodName}(${args}): ${type}`,
                   ...(method.description && { summary: method.description })
                 };
-              }),
+              }) : null,
           name: sectionName
         };
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8811,6 +8811,18 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, gl
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-dirs@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.0.1.tgz#acdf3bb6685bcd55cb35e8a052266569e9469201"
@@ -8941,7 +8953,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-handlebars@*, handlebars@^4.0.6, handlebars@^4.4.0, handlebars@^4.7.3:
+handlebars@*, handlebars@^4.0.6, handlebars@^4.4.0:
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.3.tgz#8ece2797826886cf8082d1726ff21d2a022550ee"
   integrity sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==
@@ -8956,6 +8968,18 @@ handlebars@^4.7.0, handlebars@^4.7.6:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.7.7:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.0"
@@ -9077,11 +9101,6 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
-
-highlight.js@^10.2.0:
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.3.1.tgz#3ca6bf007377faae347e8135ff25900aac734b9a"
-  integrity sha512-jeW8rdPdhshYKObedYg5XGbpVgb1/DT4AHvDFXhkU7UnGSIjy9kkJ7zHG7qplhFHMitTSzh5/iClKQk3Kb2RFQ==
 
 highlight.js@^9.0.0, highlight.js@^9.17.1:
   version "9.18.5"
@@ -11518,6 +11537,11 @@ lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-driver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
@@ -11716,10 +11740,10 @@ marked@^0.8.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
   integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
 
-marked@^1.1.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.4.tgz#94e99230b03496c9383b1322ac51bc17dd388a1d"
-  integrity sha512-6x5TFGCTKSQBLTZtOburGxCxFEBJEGYVLwCMTBCxzvyuisGcC20UNzDSJhCr/cJ/Kmh6ulfJm10g6WWEAJ3kvg==
+marked@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.2.tgz#59579e17b02443312caa1509994d5a0b18ae38e1"
+  integrity sha512-ueJhIvklJJw04qxQbGIAu63EXwwOCYc7yKMBjgagTM4rjC5QtWyqSNgW7jCosV1/Km/1TUfs5qEpAqcGG0Mo5g==
 
 math-random@^1.0.1:
   version "1.0.4"
@@ -12681,6 +12705,13 @@ onetime@^5.1.0:
   integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
   dependencies:
     mimic-fn "^2.1.0"
+
+onigasm@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.5.tgz#cc4d2a79a0fa0b64caec1f4c7ea367585a676892"
+  integrity sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
+  dependencies:
+    lru-cache "^5.1.1"
 
 opencollective-postinstall@^2.0.2:
   version "2.0.3"
@@ -14853,7 +14884,7 @@ shelljs@^0.8.2:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shelljs@^0.8.3, shelljs@^0.8.4:
+shelljs@^0.8.3:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
   integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
@@ -14866,6 +14897,14 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shiki@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.9.3.tgz#7bf7bcf3ed50ca525ec89cc09254abce4264d5ca"
+  integrity sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==
+  dependencies:
+    onigasm "^2.2.5"
+    vscode-textmate "^5.2.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -15984,10 +16023,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz#1bc55b7c8d1132844616ff6f570e1e2cd0eb7343"
-  integrity sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==
+typedoc-default-themes@^0.12.10:
+  version "0.12.10"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz#614c4222fe642657f37693ea62cad4dafeddf843"
+  integrity sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==
 
 typedoc-default-themes@^0.5.0:
   version "0.5.0"
@@ -16011,14 +16050,6 @@ typedoc-plugin-markdown@^1.1.19:
   dependencies:
     turndown "^5.0.3"
 
-typedoc-plugin-markdown@^2.2.17:
-  version "2.2.17"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.2.17.tgz#aaef7420e8268170e62c764f43740e10f842548d"
-  integrity sha512-eE6cTeqsZIbjur6RG91Lhx1vTwjR49OHwVPRlmsxY3dthS4FNRL8sHxT5Y9pkosBwv1kSmNGQEPHjMYy1Ag6DQ==
-  dependencies:
-    fs-extra "^8.1.0"
-    handlebars "^4.7.3"
-
 typedoc-plugin-markdown@^2.2.6:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.4.2.tgz#2d83fe4f279643436ebc44ca2f937855b0fd9f12"
@@ -16027,10 +16058,32 @@ typedoc-plugin-markdown@^2.2.6:
     fs-extra "^9.0.1"
     handlebars "^4.7.6"
 
+typedoc-plugin-markdown@^3.10.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.10.1.tgz#9d15c16c1a29da4c137123565019d1de967987b4"
+  integrity sha512-C7s9p6DOGagPPp65g7af8OKm6Ou0rT/TP0Nphy6PQ4w6bC9BZnlOzWt1l05ER38HhON6/2prONnYwEMK5YOYCA==
+  dependencies:
+    handlebars "^4.7.7"
+
 typedoc-plugin-no-inherit@^1.1.10:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.2.0.tgz#7f73809c04cb29c03afe5eea356534968cb717a9"
   integrity sha512-jAAslwDbm5sVpA6EQIg5twYctRi/bnT9TgZ5SwbrNpCD5xCIIylPRX9KxIoi1RJliVgCIAxWbSUzzLKGwJCkeA==
+
+typedoc@0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.21.0.tgz#d35dd69b1566032cd893f4f6f21f37156f5f78d2"
+  integrity sha512-InmPBVlpOXptIkg/WnsQhbGYhv9cuDh/cRACUSautQ0QwcJPLAK2kHcfP0Pld6z/NiDvHc159fMq2qS+b/ALUw==
+  dependencies:
+    glob "^7.1.7"
+    handlebars "^4.7.7"
+    lodash "^4.17.21"
+    lunr "^2.3.9"
+    marked "^2.1.1"
+    minimatch "^3.0.0"
+    progress "^2.0.3"
+    shiki "^0.9.3"
+    typedoc-default-themes "^0.12.10"
 
 typedoc@^0.13.0:
   version "0.13.0"
@@ -16071,23 +16124,6 @@ typedoc@^0.15.0:
     shelljs "^0.8.3"
     typedoc-default-themes "^0.6.3"
     typescript "3.7.x"
-
-typedoc@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.19.2.tgz#842a63a581f4920f76b0346bb80eb2a49afc2c28"
-  integrity sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==
-  dependencies:
-    fs-extra "^9.0.1"
-    handlebars "^4.7.6"
-    highlight.js "^10.2.0"
-    lodash "^4.17.20"
-    lunr "^2.3.9"
-    marked "^1.1.1"
-    minimatch "^3.0.0"
-    progress "^2.0.3"
-    semver "^7.3.2"
-    shelljs "^0.8.4"
-    typedoc-default-themes "^0.11.4"
 
 typescript@3.1.x, typescript@3.7.x, typescript@^3.6.3, typescript@^4.0.3:
   version "4.1.2"
@@ -16435,6 +16471,11 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vscode-textmate@^5.2.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.4.0.tgz#4b25ffc1f14ac3a90faf9a388c67a01d24257cd7"
+  integrity sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==
 
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"


### PR DESCRIPTION
Used typedoc to generate typescript doc for derive and merged the generated doc with the module..

https://github.com/cennznet/api.js/blob/deriveDocs/docs/cennznet/nft.md
https://github.com/cennznet/api.js/blob/deriveDocs/docs/cennznet/cennzx.md
https://github.com/cennznet/api.js/blob/deriveDocs/docs/cennznet/staking.md

also add the interface to doc folder so that when user navigates thro' link in the document, it know what interface is used..