### PR TITLE
Pre release branch for CENNZnet API to release 1.4.3-alpha.0 version

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.4.1"
+  "version": "1.4.3-alpha.0"
 }

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.4.3-alpha.0](https://github.com/cennznet/api.js/compare/prerelease/1.4.0...prerelease/1.4.3-alpha.0) (25/05/2021)
+## [1.4.3-alpha.0](https://github.com/cennznet/api.js/compare/prerelease/1.4.1...prerelease/1.4.3-alpha.0) (25/05/2021)
 ### Added:
     - Improved extrinsic payment option
     - Script for module specific markdown

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -9,7 +9,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
     - Script for module specific markdown
     - Api creation with option to connection via network name
     - Doc generation for derive functions
-    - usCennznet hook to connect to chain and extension and return all accounts
+    - useCennznet hook to connect to chain and extension and return all accounts
     - Generated extension release data
 ### Changed    
     - Update polkadot dependencies to 3.7.1.

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -3,9 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.3-alpha.0](https://github.com/cennznet/api.js/compare/prerelease/1.4.0...prerelease/1.4.3-alpha.0) (25/05/2021)
+### Added:
+    - Improved extrinsic payment option
+    - Script for module specific markdown
+    - Api creation with option to connection via network name
+    - Doc generation for derive functions
+    - usCennznet hook to connect to chain and extension and return all accounts
+    - Generated extension release data
+### Changed    
+    - Update polkadot dependencies to 3.7.1.
+
 ## [1.4.0](https://github.com/cennznet/api.js/compare/release/1.3.4...prerelease/1.4.0) (25/05/2021)
 ### Added:
-- NFT module derived queries
+    - NFT module derived queries
 
 ## [1.3.4](https://github.com/cennznet/api.js/compare/release/1.3.3...prerelease/1.3.4) (15/03/2021)
 ### Changed:

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cennznet/api",
-  "version":"1.4.1",
+  "version":"1.4.3-alpha.0",
   "description": "CENNZnet's javascript client",
   "keywords": [
     "CENNZnet"
@@ -19,7 +19,7 @@
     "doc": "npx compodoc --tsconfig ../../tsconfig.json --hideGenerator --theme readthedocs --includes compodoc --output ../../docs/api"
   },
   "dependencies": {
-    "@cennznet/types": "^1.4.1",
+    "@cennznet/types": "1.4.3-alpha.0",
     "@polkadot/api": "3.7.1",
     "@polkadot/metadata": "3.7.1",
     "@polkadot/rpc-core": "3.7.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,7 +19,7 @@
     "doc": "npx compodoc --tsconfig ../../tsconfig.json --hideGenerator --theme readthedocs --includes compodoc --output ../../docs/api"
   },
   "dependencies": {
-    "@cennznet/types": "1.4.3-alpha.0",
+    "@cennznet/types": "^1.4.3-alpha.0",
     "@polkadot/api": "3.7.1",
     "@polkadot/metadata": "3.7.1",
     "@polkadot/rpc-core": "3.7.1",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.2](https://github.com/cennznet/api.js/compare/release/1.4.1...prerelease/1.4.2) (15/06/2021)
+### Added:
+- LookupSource type definition
+
 ## [1.4.1](https://github.com/cennznet/api.js/compare/release/1.4.0...prerelease/1.4.1) (15/06/2021)
 ### Changed:
 - RPC types for CENNZX

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cennznet/types",
-    "version": "1.4.1",
+    "version": "1.4.3-alpha.0",
     "description": "additional types for CENNZnet api",
     "author": "Centrality Developers <support@centrality.ai>",
     "keywords": [

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cennznet/util",
-    "version": "1.4.1",
+    "version": "1.4.3-alpha.0",
     "description": "utils for CENNZnet api",
     "author": "Centrality Developers <support@centrality.ai>",
     "keywords": [


### PR DESCRIPTION
1.4.2 is already released as a part of https://github.com/cennznet/api.js/pull/344
Releasing 1.4.3-alpha.0 version