### PR TITLE
Commit extension data to master branch

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -21,7 +21,7 @@ jobs:
     - name: generate meta for extension
       uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        ref: 'master'
     - name: install dependencies
       run: yarn
     - name: start latest test node


### PR DESCRIPTION
GitHub Actions run in parallel.  From the last release pipeline https://github.com/cennznet/api.js/runs/3157338208?check_suite_focus=true
merge-release-branch completes before generate-metadata-for-extension...
generate-metadata-for-extension fails because there is nothing to commit, no new files to commit.
With this PR, committing the extension data to master in GitHub Actions