### PR TITLE
fix the extract eth signature and convert it to r,s,v part

### DIFF
--- a/packages/api/src/util/helper.ts
+++ b/packages/api/src/util/helper.ts
@@ -5,16 +5,12 @@ import { EthereumSignature } from '@polkadot/types/interfaces';
 import { H256 } from '@polkadot/types/interfaces/runtime';
 import { Api } from '@cennznet/api';
 
-// Ignore if signature is 0x000
-const IGNORE_SIGNATURE =
-  '0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
 // Splits the given Ethereum signatures into r,s,v format
 export function extractEthereumSignature(signatures: EthereumSignature[]): { r: string[]; s: string[]; v: number[] } {
   const rPart = [],
     sPart = [],
     vPart = [];
-  const filteredSignature = signatures.filter((sig) => sig.toString() !== IGNORE_SIGNATURE);
-  filteredSignature.forEach((signature) => {
+  signatures.forEach((signature) => {
     const sigU8a = signature.toU8a();
     const rSlice = sigU8a.slice(0, 32);
     const r = u8aToHex(rSlice);

--- a/packages/api/test/e2e/ethBridge.e2e.ts
+++ b/packages/api/test/e2e/ethBridge.e2e.ts
@@ -304,13 +304,13 @@ describe('Eth bridge test', () => {
       done();
     })
 
-    it( 'Get r,s,v from invalid signature', async done => {
+    it(   'Get r,s,v from invalid signature', async done => {
       const sign = api.registry.createType('EthereumSignature', '');
       const signatures = [sign];
       const { r, s, v } = extractEthereumSignature(signatures);
-      expect(r).toEqual([]);
-      expect(s).toEqual([]);
-      expect(v).toEqual([]);
+      expect(r).toEqual(['0x0000000000000000000000000000000000000000000000000000000000000000']);
+      expect(s).toEqual(['0x0000000000000000000000000000000000000000000000000000000000000000']);
+      expect(v[0]).toEqual(27);
 
       done();
     })


### PR DESCRIPTION
While testing on rata, figured out that the notary keys are
```
[
  '0xf88bc2c5918b40a8aa1905f3fc5e4b90b2a3142c',
  '0x478adb7a82be57337f433c6e515ee817b45d936e',
  '0x7d0f662f04ac77fdc1c8e51da2f9aea7c1aabc7f',
  '0x360bf1d9d6319afbbb678dea92842b76c3b4f3a9',
  '0xb94719a6a34656f76002590a52ef4d2e8a29c7ec'
]
```

and signatures in event proof comes as

```
[
"0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
"0xb209b017eba3a753f6bf56b440d901065f99e18de0de1fc65186050b44a0531d5fdbcbf7d7f87b8ed389cc9c27a79085afd681a7517fa8260c95c5dd9d0d09c200",
"0x73be4d71e2bde9ee902e8c6e6e04418d39665e14551897e61dd41f559f3103747f4123876a94dfbfd741ce6bfaae909c912d43ad5279de23da969124894fc1f900",
"0x9515c8ebba46d75b77f84bb02261662517962147ee33a528c7d7c9f45497df1877b828c235ecc80d47ec4c93668d0b991ff729ae38e5f20459236010b0320d7001",
"0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
]
```
so we should not ignore `0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
as it has to be one -to- one with notary keys