### PR TITLE
for rtm < 47, use specific session key

### DIFF
--- a/packages/types/src/interfaces/injects.ts
+++ b/packages/types/src/interfaces/injects.ts
@@ -86,7 +86,8 @@ export const typesBundle: OverrideBundleType = {
           minmax: [41, 45],
           types: {
             ...sharedTypes41Onwards,
-            BalanceLock: 'BalanceLock45'
+            BalanceLock: 'BalanceLock45',
+            Keys: '(AccountId, AccountId, AccountId, AccountId, BeefyKey)'
           },
         },
         {

--- a/packages/types/src/interfaces/injects.ts
+++ b/packages/types/src/interfaces/injects.ts
@@ -83,7 +83,7 @@ export const typesBundle: OverrideBundleType = {
           },
         },
         {
-          minmax: [41, 47],
+          minmax: [41, 48],
           types: {
             ...sharedTypes41Onwards,
             BalanceLock: 'BalanceLock45',
@@ -91,7 +91,7 @@ export const typesBundle: OverrideBundleType = {
           },
         },
         {
-          minmax: [48, undefined],
+          minmax: [49, undefined],
           types: {
             ...sharedTypes41Onwards
           },

--- a/packages/types/src/interfaces/injects.ts
+++ b/packages/types/src/interfaces/injects.ts
@@ -83,7 +83,7 @@ export const typesBundle: OverrideBundleType = {
           },
         },
         {
-          minmax: [41, 45],
+          minmax: [41, 47],
           types: {
             ...sharedTypes41Onwards,
             BalanceLock: 'BalanceLock45',
@@ -91,7 +91,7 @@ export const typesBundle: OverrideBundleType = {
           },
         },
         {
-          minmax: [46, undefined],
+          minmax: [48, undefined],
           types: {
             ...sharedTypes41Onwards
           },


### PR DESCRIPTION
Description- for runtime at which azalea currently is, Key type should be '(AccountId, AccountId, AccountId, AccountId, BeefyKey)'

Donno if we want to spin a dev node on 2.0.0 in ci and have test against that.