### PR TITLE
Fixes lock balance for rtm version <= 48

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [UNRELEASED]
+Please check [upgrade guide](https://hackmd.io/VbsHZhKkTiWwaTBYp1Unbw) for 2.1.x  version
 ## [2.1.0-rc.2](https://github.com/cennznet/api.js/compare/prerelease/2.1.0-rc.1...prerelease/2.1.0-rc.2) (28/03/2022)
 ### Added:
     - Derive query to get metadata uri for a series (api.derive.nft.seriesMetadataUri)

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -53,3 +53,4 @@ After connecting to a CENNZnet node, api will dynamically create queries and tra
 ---
 
 See the [wiki](https:///wiki.cennz.net) for more or try the [api examples](../../docs/examples)
+Please check [upgrade guide](https://hackmd.io/VbsHZhKkTiWwaTBYp1Unbw) for 2.1.x versions, connects to node  cennznet/cennznet:2.1.0

--- a/packages/api/test/e2e/api.create.e2e.ts
+++ b/packages/api/test/e2e/api.create.e2e.ts
@@ -35,6 +35,15 @@ describe('e2e api create', () => {
     bob = keyring.addFromUri('//Bob');
   });
 
+  it('Find lock balance for azalea validator', async () => {
+    const api = await Api.create({network: 'azalea'});
+    const cennzAssetId = 1;
+    const validator = "5FCdFHNPR62USs3xeA8Pnj2D87n4RLG1xRB2jS4tbcs7t19j";
+    const lockBalance = await api.query.genericAsset.locks(cennzAssetId, validator);
+    expect((lockBalance.toJSON())[0].amount).toBeGreaterThanOrEqual(0);
+    await api.disconnect();
+  });
+
   it('Should get rejected if it is not resolved in a specific period of time', async () => {
     const provider = config.wsProvider[`${process.env.TEST_TYPE}`];
     await expect(Api.create({provider, timeout: 1})).rejects.toThrow(

--- a/packages/types/src/interfaces/injects.ts
+++ b/packages/types/src/interfaces/injects.ts
@@ -70,7 +70,8 @@ export const typesBundle: OverrideBundleType = {
             ExtrinsicSignatureV4: CENNZnetExtrinsicSignatureV0,
             ExtrinsicPayloadV4: CENNZnetExtrinsicPayloadV0,
             AssetInfo: 'AssetInfoV40',
-            BalanceLock: 'BalanceLock45'
+            BalanceLock: 'BalanceLock45',
+            Reasons: 'WithdrawReasons',
           },
         },
         {
@@ -79,6 +80,7 @@ export const typesBundle: OverrideBundleType = {
             ...shareType37Onwards,
             AssetInfo: 'AssetInfoV40',
             Proposal: 'GovernanceProposal',
+            Reasons: 'WithdrawReasons',
             BalanceLock: 'BalanceLock45'
           },
         },
@@ -87,6 +89,7 @@ export const typesBundle: OverrideBundleType = {
           types: {
             ...sharedTypes41Onwards,
             BalanceLock: 'BalanceLock45',
+            Reasons: 'WithdrawReasons',
             Keys: '(AccountId, AccountId, AccountId, AccountId, BeefyKey)'
           },
         },


### PR DESCRIPTION

<img width="1787" alt="Screen Shot 2022-04-01 at 1 15 13 PM" src="https://user-images.githubusercontent.com/29415595/161178532-23557afd-7b84-4249-8ac4-c237b60baff1.png">
<img width="1787" alt="Screen Shot 2022-04-01 at 2 45 41 PM" src="https://user-images.githubusercontent.com/29415595/161178569-ce1770af-a1e0-487d-97e6-d270f7263692.png">
Desc - Currently the balance lock query for generic asset fails with rc3.. This PR fixes that. Also added link to upgrade guide so that it appears on npm registry.

File changed - 
packages/api/CHANGELOG.md
packages/api/README.md
packages/api/test/e2e/api.create.e2e.ts (added test)
packages/types/src/interfaces/injects.ts - use specific Reasons type 