### PR TITLE
attempt to fix type definition for rpc calls

### DIFF
--- a/packages/api/src/Api.ts
+++ b/packages/api/src/Api.ts
@@ -14,11 +14,12 @@
 
 import { Hash } from '@cennznet/types';
 import { ApiPromise } from '@polkadot/api';
-import { ApiOptions as ApiOptionsBase, SubmittableExtrinsics } from '@polkadot/api/types';
+import { ApiOptions as ApiOptionsBase, DecoratedRpc, SubmittableExtrinsics } from '@polkadot/api/types';
 
 import * as definitions from '@cennznet/types/interfaces/definitions';
 import Types, { typesBundle } from '@cennznet/types/interfaces/injects';
 import { getMetadata } from '@cennznet/api/util/getMetadata';
+import type { RpcInterface } from '@polkadot/rpc-core/types/jsonrpc';
 import { decorateExtrinsics } from '@polkadot/types';
 import { CallFunction } from '@polkadot/types/types';
 import { assertReturn, u8aToHex, u8aToU8a } from '@polkadot/util';
@@ -67,6 +68,10 @@ export class Api extends ApiPromise {
 
   get derive(): Derives<'promise'> {
     return super.derive as Derives<'promise'>;
+  }
+
+  get rpc(): DecoratedRpc<'promise', RpcInterface> {
+    return super.rpc as DecoratedRpc<'promise', RpcInterface>;
   }
 
   constructor(_options: ApiOptions = {}) {

--- a/packages/api/src/ApiRx.ts
+++ b/packages/api/src/ApiRx.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import { ApiRx as ApiRxBase } from '@polkadot/api';
-import { ApiOptions as ApiOptionsBase, SubmittableExtrinsics } from '@polkadot/api/types';
+import { ApiOptions as ApiOptionsBase, DecoratedRpc, SubmittableExtrinsics } from '@polkadot/api/types';
+import type { RpcInterface } from '@polkadot/rpc-core/types/jsonrpc';
 import { Observable } from 'rxjs';
 import { timeout } from 'rxjs/operators';
 
@@ -59,6 +60,10 @@ export class ApiRx extends ApiRxBase {
 
   get derive(): Derives<'rxjs'> {
     return super.derive as Derives<'rxjs'>;
+  }
+
+  get rpc(): DecoratedRpc<'rxjs', RpcInterface> {
+    return super.rpc as DecoratedRpc<'rxjs', RpcInterface>;
   }
 
   constructor(_options: ApiOptions = {}) {


### PR DESCRIPTION
Details - Fix the rpc definition for cennznet.


https://github.com/cennznet/api.js/blob/89ea3074f37ff9896fb67ff00648fcbbbe4a28c2/packages/types/src/interfaces/augment-api-rpc.ts#L36
Augments the '@polkadot/rpc-core/types/jsonrpc' RpcInterface interface